### PR TITLE
Fix CI build cache: registry-based caching via ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,15 @@ on:
 
 env:
   USE_DOCKER: 1
+  CC_CACHE_IMAGE: ghcr.io/${{ github.repository_owner }}/ak2-dashboard/arm-cross-cc
+  E2E_CACHE_IMAGE: ghcr.io/${{ github.repository_owner }}/ak2-dashboard/e2e-testbed
 
 jobs:
   checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -34,27 +39,24 @@ jobs:
         with:
           platforms: arm
 
-      - name: Restore cross-compiler image cache
-        id: cache-cc-image
-        uses: actions/cache@v4
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
         with:
-          path: /tmp/arm-cross-cc.tar
-          key: podman-arm-cross-cc-${{ hashFiles('src/build.Dockerfile') }}
-
-      - name: Load cross-compiler image from cache
-        if: steps.cache-cc-image.outputs.cache-hit == 'true'
-        run: podman load -i /tmp/arm-cross-cc.tar
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run linting and tests
         run: make lint test
-
-      - name: Save cross-compiler image to cache
-        if: steps.cache-cc-image.outputs.cache-hit != 'true'
-        run: podman save localhost/arm-cross-cc -o /tmp/arm-cross-cc.tar
+        env:
+          DOCKER_CACHE_IMAGE: ${{ env.CC_CACHE_IMAGE }}
 
   build:
     needs: checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -70,23 +72,17 @@ jobs:
         with:
           platforms: arm
 
-      - name: Restore cross-compiler image cache
-        id: cache-cc-image
-        uses: actions/cache@v4
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
         with:
-          path: /tmp/arm-cross-cc.tar
-          key: podman-arm-cross-cc-${{ hashFiles('src/build.Dockerfile') }}
-
-      - name: Load cross-compiler image from cache
-        if: steps.cache-cc-image.outputs.cache-hit == 'true'
-        run: podman load -i /tmp/arm-cross-cc.tar
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build project
         run: make
-
-      - name: Save cross-compiler image to cache
-        if: steps.cache-cc-image.outputs.cache-hit != 'true'
-        run: podman save localhost/arm-cross-cc -o /tmp/arm-cross-cc.tar
+        env:
+          DOCKER_CACHE_IMAGE: ${{ env.CC_CACHE_IMAGE }}
 
       - name: Upload package
         uses: actions/upload-artifact@v4
@@ -102,6 +98,9 @@ jobs:
   e2e:
     needs: checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -122,27 +121,12 @@ jobs:
       - name: Install Playwright system dependencies
         run: npx --yes playwright install-deps chromium
 
-      - name: Restore cross-compiler image cache
-        id: cache-cc-image
-        uses: actions/cache@v4
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
         with:
-          path: /tmp/arm-cross-cc.tar
-          key: podman-arm-cross-cc-${{ hashFiles('src/build.Dockerfile') }}
-
-      - name: Load cross-compiler image from cache
-        if: steps.cache-cc-image.outputs.cache-hit == 'true'
-        run: podman load -i /tmp/arm-cross-cc.tar
-
-      - name: Restore testbed image cache
-        id: cache-testbed-image
-        uses: actions/cache@v4
-        with:
-          path: /tmp/e2e-testbed.tar
-          key: podman-e2e-testbed-${{ hashFiles('e2e/Dockerfile', 'e2e/config/**', 'e2e/scripts/**') }}
-
-      - name: Load testbed image from cache
-        if: steps.cache-testbed-image.outputs.cache-hit == 'true'
-        run: podman load -i /tmp/e2e-testbed.tar
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run E2E pipeline
         run: make e2e
@@ -152,14 +136,8 @@ jobs:
           E2E_UI_TRANSITION_TIMEOUT: 2000
           E2E_PAGE_LOAD_TIMEOUT: 5000
           E2E_LOG_REFRESH_TIMEOUT: 3000
-
-      - name: Save cross-compiler image to cache
-        if: steps.cache-cc-image.outputs.cache-hit != 'true'
-        run: podman save localhost/arm-cross-cc -o /tmp/arm-cross-cc.tar
-
-      - name: Save testbed image to cache
-        if: steps.cache-testbed-image.outputs.cache-hit != 'true'
-        run: podman save localhost/e2e_printer-testbed -o /tmp/e2e-testbed.tar
+          DOCKER_CACHE_IMAGE: ${{ env.CC_CACHE_IMAGE }}
+          E2E_CACHE_IMAGE: ${{ env.E2E_CACHE_IMAGE }}
 
       - name: Upload Playwright report
         if: failure()

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -34,6 +34,8 @@ E2E_SOURCES := $(shell find $(ROOT_DIR)/src -type f \( -name '*.c' -o -name '*.h
 E2E_IMAGE := localhost/e2e_printer-testbed
 E2E_CONTAINER := ak2-testbed
 E2E_PLATFORM := linux/arm/v7
+# Optional registry image for build cache (registry/repo format, no tag - podman --cache-from/--cache-to)
+E2E_CACHE_IMAGE ?=
 
 # E2E testbed ports
 E2E_SSH_PORT ?= 20022
@@ -59,7 +61,7 @@ build-image: ## Build the E2E testbed container image
 	@$(DOCKER) build \
 		--pull=never \
 		--network=host \
-		$(shell $(DOCKER) image exists $(E2E_IMAGE) 2>/dev/null && echo --cache-from $(E2E_IMAGE)) \
+		$(if $(E2E_CACHE_IMAGE),--layers --cache-from $(E2E_CACHE_IMAGE) --cache-to $(E2E_CACHE_IMAGE)) \
 		--platform $(E2E_PLATFORM) \
 		-t $(E2E_IMAGE) \
 		-f Dockerfile \

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,6 +17,8 @@ ARROW := $(BLUE)➜$(NC)
 DOCKER := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 DOCKER_IMAGE := localhost/arm-cross-cc
 DOCKER_PLATFORM := linux/arm/v7
+# Optional registry image for build cache (registry/repo format, no tag - podman --cache-from/--cache-to)
+DOCKER_CACHE_IMAGE ?=
 
 # JSON library configuration
 JSMN_DIR := ./vendor/jsmn
@@ -83,7 +85,7 @@ docker-image: ## Build container image for cross-compilation
 	@$(CURDIR)/../scripts/pull-base-images.sh $(DOCKER_PLATFORM) build.Dockerfile
 	@$(DOCKER) build \
 		--pull=never \
-		$(shell $(DOCKER) image exists $(DOCKER_IMAGE) 2>/dev/null && echo --cache-from $(DOCKER_IMAGE)) \
+		$(if $(DOCKER_CACHE_IMAGE),--layers --cache-from $(DOCKER_CACHE_IMAGE) --cache-to $(DOCKER_CACHE_IMAGE)) \
 		--platform $(DOCKER_PLATFORM) \
 		-t $(DOCKER_IMAGE) \
 		-f build.Dockerfile .


### PR DESCRIPTION
## Problem

The CI cache was broken. Images loaded via `podman load` do not transfer build layer metadata, so subsequent `podman build --cache-from localhost/...` always rebuilds from scratch.

Root causes:
- `--cache-from` with a **local** image name doesn't work in podman/buildah — it expects a remote registry
- `--cache-from/--cache-to` require `--layers` to have any effect
- `--cache-from/--cache-to` accept `registry/repo` format **without a tag** (podman generates random digest-based tags internally)

## Solution

Replace `actions/cache` + `podman save/load` with proper registry-based caching using `--layers --cache-from/--cache-to` against `ghcr.io`.

### Changes

- `.github/workflows/ci.yml`: Remove `actions/cache` + `podman save/load` steps; add `redhat-actions/podman-login` + `packages: write` permission; pass `DOCKER_CACHE_IMAGE`/`E2E_CACHE_IMAGE` env vars to make
- `src/Makefile`: Use `DOCKER_CACHE_IMAGE` var with `--layers --cache-from/--cache-to` (no-op when unset — safe for local dev)
- `e2e/Makefile`: Same pattern with `E2E_CACHE_IMAGE`

### Verification

Tested locally against `ghcr.io/wavesoftware/ak2-dashboard/arm-cross-cc`:

**Run 1** (cold): Builds all layers, pushes cache to registry  
**Run 2** (after removing all local images): `Cache pulled from remote ghcr.io/...` for every layer — zero rebuild ✔

---

Assisted-by: 🤖 Claude Sonnet 4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline infrastructure with improved caching mechanisms for build and end-to-end test workflows.
  * Added explicit permission controls to automated checks and build processes.
  * Streamlined container image handling in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->