### PR TITLE
feat: Z-offset stored per leveling slot

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -83,6 +83,30 @@ Slots store individual mesh measurements from each leveling pass. They are:
 - **Profile-specific** - Each profile (including Current) has its own isolated slots
 - **Numbered 1-99** - Automatically assigned or manually specified
 
+Each slot is stored as a `.txt` file with up to two lines:
+
+```
++0.081000, -0.022000, ...   ← line 1: mesh CSV data
+1.4430                      ← line 2: z_offset (optional)
+```
+
+Slots saved before z-offset support was added contain only line 1 (legacy format). These are fully supported — their z-offset shows as "—".
+
+### Z-offset per Slot
+
+Every slot row displays its z-offset value alongside the mesh data. This includes the active mesh, all saved slots, and the computed average.
+
+- **Inline editing** — Click the z-offset value on any slot row to edit it. Press Enter or click away to save. The active slot updates `printer.cfg` immediately; saved slots update the slot file.
+- **Average slot** — Z-offset is read-only and computed from all slots that have a z-offset. Legacy slots (no z-offset) are excluded from the average. If no slots have a z-offset the average shows "—".
+- **Legacy slots** — Display "z: —". You can add a z-offset by clicking the label and entering a value.
+
+### Safe Activation
+
+When activating a slot or average as the current mesh:
+
+- **Slot with z-offset** — Both mesh points and z-offset are written to `printer.cfg`.
+- **Slot without z-offset (legacy)** — Only mesh points are updated. The existing z-offset in `printer.cfg` is preserved, preventing accidental data loss.
+
 ## Profiles
 
 Profiles let you save and restore complete leveling configurations for different scenarios (build surfaces, materials, backups). They are dashboard-only features - the printer firmware doesn't know about them. They are snapshots you can restore later.
@@ -104,7 +128,7 @@ Profiles let you save and restore complete leveling configurations for different
 **What Profiles Store**
 - Grid size, bed temp, precision settings
 - Active mesh data
-- All saved slot measurements
+- All saved slot measurements, including z-offset per slot
 
 **Limitations**
 - Maximum 20 profiles, 99 slots per profile
@@ -326,6 +350,11 @@ To verify your configuration:
 - This is normal for stock firmware
 - Use the averaging system (5-6 slots minimum)
 - Check probe cleanliness
+
+**Legacy Slots Showing "z: —"**
+- Slots saved before z-offset support show "—" instead of a value
+- They were saved before this feature was introduced
+- To add a z-offset: click the "—" label on the slot row, enter the value, and press Enter
 
 **Grid Size Errors**
 - Increase grid by one point at a time

--- a/DOCS.md
+++ b/DOCS.md
@@ -85,7 +85,7 @@ Slots store individual mesh measurements from each leveling pass. They are:
 
 Each slot is stored as a `.txt` file with up to two lines:
 
-```
+```text
 +0.081000, -0.022000, ...   ← line 1: mesh CSV data
 1.4430                      ← line 2: z_offset (optional)
 ```

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -47,8 +47,8 @@ E2E_HTTP_PORT ?= 20080
 E2E_GEN_MESH_CMD ?= sshpass -p 'toor' ssh -o StrictHostKeyChecking=no \
 	-o UserKnownHostsFile=/dev/null -p $(E2E_SSH_PORT) root@localhost '/opt/scripts/gen-bed-mesh.sh'
 
-.PHONY: up down deploy gen-mesh clean test test-ui test-debug test-headed init help all-clean \
-	build-image
+.PHONY: up down deploy gen-mesh clean test test-ui test-debug test-headed test-perf init help \
+	all-clean build-image
 
 build-image: ## Build the E2E testbed container image
 	@echo ""
@@ -183,11 +183,19 @@ test-headed: init ## Run E2E tests with browser visible
 		npm run test:headed
 	@echo ""
 
-all: $(E2E_ALL_STAMP) ## Run the full E2E pipeline: up, deploy, test, down
+test-perf: init ## Run memory leak detection perf test (requires testbed running)
+	@echo ""
+	@echo "$(BLUE)➜ Running memory leak detection perf test...$(NC)"
+	@E2E_BASE_URL=http://localhost:$(E2E_HTTP_PORT) \
+		npm run test:perf
+	@echo ""
+
+all: $(E2E_ALL_STAMP) ## Run the full E2E pipeline: up, deploy, test-perf, test, down
 
 $(E2E_ALL_STAMP): $(E2E_SOURCES) node_modules/.playwright-installed
 	@$(MAKE) up
 	@$(MAKE) deploy
+	@$(MAKE) test-perf
 	@$(MAKE) test
 	@$(MAKE) down
 	@mkdir -p $(STAMP_DIR)

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -12,7 +12,450 @@
         "@lavamoat/allow-scripts": "^3.3.1",
         "@lavamoat/preinstall-always-fail": "^2.1.0",
         "@playwright/test": "^1.52.0",
-        "@types/node": "^25.2.3"
+        "@types/node": "^25.2.3",
+        "tsx": "^4.19.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/balanced-match": {
@@ -428,6 +871,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -509,6 +994,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -1159,6 +1657,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -1366,6 +1874,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/type-fest": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,19 +9,23 @@
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",
     "test:headed": "playwright test --headed",
-    "test:report": "playwright show-report"
+    "test:report": "playwright show-report",
+    "test:perf": "npx tsx tests/perf.ts"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.3.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@playwright/test": "^1.52.0",
-    "@types/node": "^25.2.3"
+    "@types/node": "^25.2.3",
+    "tsx": "^4.19.3"
   },
   "lavamoat": {
     "allowScripts": {
       "$root$": true,
       "@lavamoat/preinstall-always-fail": false,
-      "@playwright/test": true
+      "@playwright/test": true,
+      "tsx": false,
+      "tsx>esbuild": false
     }
   }
 }

--- a/e2e/scripts/gen-bed-mesh.sh
+++ b/e2e/scripts/gen-bed-mesh.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
-# Simulates bed mesh leveling by generating mesh points in printer.cfg
+# Simulates bed mesh leveling by generating mesh points and z-offset in printer.cfg
 # This mimics what the vendor app does when running bed leveling
 
 CONFIG_FILE="/user/printer.cfg"
+
+# Generate a realistic z-offset value in the range 1.25mm to 1.65mm
+# Uses awk for floating-point arithmetic (available in BusyBox)
+generate_z_offset() {
+    awk 'BEGIN { srand(); printf "%.4f\n", 1.25 + (rand() * 0.40) }'
+}
 
 # Get grid size from probe_count in config (e.g., "5,5" -> 5)
 get_grid_size() {
@@ -104,6 +110,7 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 
 MESH_POINTS=$(generate_mesh_points)
+Z_OFFSET=$(generate_z_offset)
 
 # Check if points line already exists
 if grep -q "^points : " "$CONFIG_FILE"; then
@@ -114,7 +121,15 @@ else
     sed -i "/^algorithm : /a points : $MESH_POINTS" "$CONFIG_FILE"
 fi
 
-# Verify the change
+# Update z_offset under [probe] in printer.cfg
+if grep -q "^z_offset : " "$CONFIG_FILE"; then
+    echo "Updating z_offset in printer.cfg..."
+    sed -i "s/^z_offset : .*/z_offset : $Z_OFFSET/" "$CONFIG_FILE"
+else
+    echo "z_offset line not found in printer.cfg, skipping update"
+fi
+
+# Verify the changes
 if grep -q "^points : " "$CONFIG_FILE"; then
     echo "SUCCESS: Mesh points generated!"
     grep "^points : " "$CONFIG_FILE"
@@ -122,3 +137,4 @@ else
     echo "ERROR: Failed to add mesh points"
     exit 1
 fi
+echo "Z-offset: $Z_OFFSET"

--- a/e2e/tests/leveling.spec.ts
+++ b/e2e/tests/leveling.spec.ts
@@ -139,7 +139,7 @@ test.describe('Leveling Page - Slot Operations', () => {
       const slotNumber = Math.floor(Math.random() * 90) + 10; // Random slot 10-99
 
       // Open save modal
-      const activeMeshSection = page.locator('text=Active Mesh').locator('..');
+      const activeMeshSection = page.locator('.mesh-item').filter({ hasText: 'Active Mesh' });
       await activeMeshSection.getByRole('button', { name: 'Save' }).click();
 
       const dialog = page.getByRole('dialog');
@@ -160,7 +160,7 @@ test.describe('Leveling Page - Slot Operations', () => {
 
     test('should save mesh, generate new mesh, save second slot', async ({ page }) => {
       // Save first mesh to slot 1
-      const activeMeshSection = page.locator('text=Active Mesh').locator('..');
+      const activeMeshSection = page.locator('.mesh-item').filter({ hasText: 'Active Mesh' });
       await activeMeshSection.getByRole('button', { name: 'Save' }).click();
       
       let dialog = page.getByRole('dialog');
@@ -177,7 +177,7 @@ test.describe('Leveling Page - Slot Operations', () => {
       await page.waitForSelector('text=Profile');
 
       // Save second mesh to slot 2
-      const activeMeshSection2 = page.locator('text=Active Mesh').locator('..');
+      const activeMeshSection2 = page.locator('.mesh-item').filter({ hasText: 'Active Mesh' });
       await activeMeshSection2.getByRole('button', { name: 'Save' }).click();
       
       dialog = page.getByRole('dialog');
@@ -204,7 +204,7 @@ test.describe('Leveling Page - Slot Operations', () => {
       // Create a slot (99) to ensure we have one to delete
       const slotNumber = 99;
 
-      const activeMeshSection = page.locator('text=Active Mesh').locator('..');
+      const activeMeshSection = page.locator('.mesh-item').filter({ hasText: 'Active Mesh' });
       await activeMeshSection.getByRole('button', { name: 'Save' }).click();
       
       const dialog = page.getByRole('dialog');
@@ -372,5 +372,50 @@ test.describe('Leveling Page - Settings', () => {
     await dropdown.selectOption('1');
     const backupBedTempAfterSwitch = settingsForm.locator('input[type="number"]').nth(1);
     await expect(backupBedTempAfterSwitch).toHaveValue(backupBedTemp, { timeout: UI_TRANSITION_TIMEOUT + EXPECT_TIMEOUT });
+  });
+});
+
+test.describe('Leveling Page - Z-offset', () => {
+  test.beforeEach(async ({ page }) => {
+    await generateBedMesh();
+    await page.goto('/leveling');
+    await page.waitForSelector('text=Profile');
+  });
+
+  test('should show z-offset labels and allow inline editing on a saved slot', async ({ page }) => {
+    // Save a slot (reuses slot 77 to avoid clashing with existing tests)
+    const slotNumber = 77;
+    const activeMeshSection = page.locator('.mesh-item').filter({ hasText: 'Active Mesh' });
+    await activeMeshSection.getByRole('button', { name: 'Save' }).click();
+    let dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: EXPECT_TIMEOUT });
+    await dialog.getByRole('spinbutton', { name: /Slot Number/i }).fill(String(slotNumber));
+    await dialog.getByRole('button', { name: 'Save' }).click();
+    await expect(page.locator(`text=saved to slot ${slotNumber}`)).toBeVisible({ timeout: EXPECT_TIMEOUT });
+
+    // The saved slot row should have a z-offset label (button for editing)
+    const slotRow = page.locator(`.slot-name:has-text("Slot ${slotNumber}")`).locator('..');
+    const zOffsetLabel = slotRow.locator('.zoffset-label').first();
+    await expect(zOffsetLabel).toBeVisible({ timeout: EXPECT_TIMEOUT });
+
+    // Click to enter inline edit mode
+    await zOffsetLabel.click();
+    const zInput = slotRow.locator('.zoffset-input');
+    await expect(zInput).toBeVisible({ timeout: EXPECT_TIMEOUT });
+
+    // Enter new z-offset and confirm with Enter
+    await zInput.fill('1.2500');
+    await zInput.press('Enter');
+
+    // Input closes and label updates
+    await expect(slotRow.locator('.zoffset-input')).not.toBeVisible({ timeout: EXPECT_TIMEOUT });
+    await expect(slotRow.locator('.zoffset-label').first()).toContainText('1.25', { timeout: EXPECT_TIMEOUT });
+
+    // Average slot z-offset should now show a value (not legacy dash)
+    const averageRow = page.locator('text=Average').locator('..');
+    const avgZOffset = averageRow.locator('.zoffset-label.readonly');
+    await expect(avgZOffset).toBeVisible({ timeout: EXPECT_TIMEOUT });
+    const avgText = await avgZOffset.textContent();
+    expect(avgText).not.toContain('—');
   });
 });

--- a/e2e/tests/perf.ts
+++ b/e2e/tests/perf.ts
@@ -1,0 +1,150 @@
+/**
+ * Memory Leak Detection Script
+ *
+ * Detects memory leaks by hammering all major GET API paths.
+ * Critical because the printer has only ~109MB RAM.
+ *
+ * Uses `docker/podman exec` to read the webfsd process RSS directly from
+ * /proc/<pid>/statm — insulated from OS page cache noise that makes
+ * system-wide free_mem measurements unreliable.
+ *
+ * A warmup burst primes page caches before the baseline is taken so that
+ * the before/after measurements are on equal footing.
+ *
+ * Run with: npx tsx tests/perf.ts
+ * Env vars:
+ *   E2E_BASE_URL      - Base URL of the webserver (default: http://localhost:20080)
+ *   E2E_CONTAINER     - Container name (default: ak2-testbed)
+ *   PERF_ITERS        - Number of burst iterations per path (default: 500)
+ *   PERF_MAX_GROW_KB  - Max allowed RSS increase in KB (default: 15)
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:20080';
+const CONTAINER = process.env.E2E_CONTAINER ?? 'ak2-testbed';
+const ITERS = parseInt(process.env.PERF_ITERS ?? '500', 10);
+const MAX_GROW_KB = parseInt(process.env.PERF_MAX_GROW_KB ?? '15', 10);
+
+const PATHS = [
+  '/api/system',
+  '/api/profiles',
+  '/api/profiles/current',
+  '/api/profiles/1',
+  '/api/webserver',
+  '/',
+];
+
+/** Detect whether podman or docker is available. */
+async function detectDocker(): Promise<string> {
+  for (const cmd of ['podman', 'docker']) {
+    try {
+      await execAsync(`command -v ${cmd}`);
+      return cmd;
+    } catch {
+      // not found, try next
+    }
+  }
+  throw new Error('Neither podman nor docker found in PATH');
+}
+
+/**
+ * Read the webfsd process RSS in bytes from inside the container.
+ * Uses pgrep to find the PID via "/opt/bin/webfsd " pattern (trailing space
+ * avoids matching webfsd-runner), then reads /proc/<pid>/statm field 2 (RSS pages).
+ */
+async function getProcessRss(docker: string): Promise<number> {
+  // Get PID of webfsd (pattern from e2e/scripts/poweroff)
+  const { stdout: pidOut } = await execAsync(
+    `${docker} exec ${CONTAINER} sh -c 'pgrep -f "/opt/bin/webfsd " | head -1'`
+  );
+  const pid = pidOut.trim();
+  if (!pid) throw new Error('webfsd process not found in container');
+
+  // Read statm: fields are (pages): vsize rss shared text lib data dirty
+  const { stdout: statmOut } = await execAsync(
+    `${docker} exec ${CONTAINER} sh -c 'cat /proc/${pid}/statm'`
+  );
+  const fields = statmOut.trim().split(/\s+/);
+  const rssPages = parseInt(fields[1], 10);
+  if (isNaN(rssPages)) throw new Error(`Unexpected /proc/${pid}/statm output: ${statmOut.trim()}`);
+
+  // Page size (ARM typically 4096, but ask the container)
+  const { stdout: psOut } = await execAsync(
+    `${docker} exec ${CONTAINER} sh -c 'getconf PAGESIZE 2>/dev/null || echo 4096'`
+  );
+  const pageSize = parseInt(psOut.trim(), 10) || 4096;
+  return rssPages * pageSize;
+}
+
+async function burst(path: string, iters: number): Promise<void> {
+  const url = `${BASE_URL}${path}`;
+  for (let i = 0; i < iters; i++) {
+    const res = await fetch(url);
+    await res.arrayBuffer(); // consume body to release connection
+  }
+}
+
+async function main(): Promise<void> {
+  const docker = await detectDocker();
+  console.log(`Memory leak detection (process RSS via ${docker} exec)`);
+  console.log(`  Base URL  : ${BASE_URL}`);
+  console.log(`  Container : ${CONTAINER}`);
+  console.log(`  Paths     : ${PATHS.length}`);
+  console.log(`  Iters     : ${ITERS} per path`);
+  console.log(`  Max grow  : ${MAX_GROW_KB} KB`);
+  console.log('');
+
+  // Warmup — prime page caches so baseline is taken in a hot state
+  console.log('Warmup burst (priming caches)...');
+  for (const path of PATHS) {
+    await burst(path, 20);
+  }
+  await new Promise(resolve => setTimeout(resolve, 500));
+  console.log('Warmup done.');
+  console.log('');
+
+  // Baseline RSS
+  const baselineRss = await getProcessRss(docker);
+  console.log(`Baseline webfsd RSS: ${(baselineRss / 1024).toFixed(1)} KB`);
+  console.log('');
+
+  // Burst all paths
+  for (const path of PATHS) {
+    process.stdout.write(`  Bursting ${path.padEnd(30)} (${ITERS} reqs) ... `);
+    const t0 = Date.now();
+    await burst(path, ITERS);
+    const elapsed = Date.now() - t0;
+    console.log(`done in ${elapsed}ms`);
+  }
+
+  console.log('');
+  console.log('Waiting 1s for allocator to settle...');
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // Final RSS
+  const finalRss = await getProcessRss(docker);
+  console.log(`Final webfsd RSS   : ${(finalRss / 1024).toFixed(1)} KB`);
+
+  const growBytes = finalRss - baselineRss;
+  const growKB = growBytes / 1024;
+  console.log('');
+  console.log(`RSS change         : ${growKB >= 0 ? '+' : ''}${growKB.toFixed(1)} KB`);
+
+  if (growKB > MAX_GROW_KB) {
+    console.error('');
+    console.error(`FAIL: RSS grew by ${growKB.toFixed(1)} KB which exceeds threshold of ${MAX_GROW_KB} KB`);
+    console.error('Possible memory leak detected!');
+    process.exit(1);
+  }
+
+  console.log(`PASS: RSS growth (${growKB.toFixed(1)} KB) is within threshold (${MAX_GROW_KB} KB)`);
+}
+
+main().catch(err => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});

--- a/frontend/src/lib/api/profiles.ts
+++ b/frontend/src/lib/api/profiles.ts
@@ -7,25 +7,22 @@ export interface ProfileSettings {
   grid_size: number
   bed_temp: number
   precision: number
-  z_offset: number // z_offset is returned in settings by the C backend
 }
 
-export interface MeshData {
+/** A slot represents any mesh data entry: active mesh or a saved slot */
+export interface Slot {
+  id?: number // present for saved slots; absent for active_mesh
+  date?: string // present for saved slots
   mesh_data: string
-}
-
-export interface SavedMesh {
-  id: number
-  date: string
-  mesh_data: string
+  z_offset?: number // undefined = legacy slot without z_offset
 }
 
 export interface ProfileDetails {
   id: number | "current"
   name?: string // Optional for "current" profile
   settings: ProfileSettings
-  active_mesh: MeshData
-  saved_meshes: SavedMesh[]
+  active_slot: Slot
+  saved_slots: Slot[]
   loaded_from?: number // Optional, indicates which profile was last applied to Current
 }
 
@@ -145,11 +142,30 @@ export async function saveSlot(
   profileId: number | "current",
   slotId: number,
   meshData: string,
+  zOffset?: number,
+): Promise<{ status: string; message: string }> {
+  const body: Record<string, unknown> = { mesh_data: meshData }
+  if (zOffset !== undefined) body.z_offset = zOffset
+  const response = await fetch(`${API_BASE}/${profileId}/slots/${slotId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  return handleResponse(response)
+}
+
+/**
+ * Update only z_offset for a saved slot (partial update)
+ */
+export async function updateSlotZOffset(
+  profileId: number | "current",
+  slotId: number,
+  zOffset: number,
 ): Promise<{ status: string; message: string }> {
   const response = await fetch(`${API_BASE}/${profileId}/slots/${slotId}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ mesh_data: meshData }),
+    body: JSON.stringify({ z_offset: zOffset }),
   })
   return handleResponse(response)
 }
@@ -173,11 +189,14 @@ export async function deleteSlot(
 export async function updatePrinterMesh(
   profileId: number | "current",
   meshData: string,
+  zOffset?: number,
 ): Promise<{ status: string; message: string }> {
+  const body: Record<string, unknown> = { mesh_data: meshData }
+  if (zOffset !== undefined) body.z_offset = zOffset
   const response = await fetch(`${API_BASE}/${profileId}/printer-mesh`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ mesh_data: meshData }),
+    body: JSON.stringify(body),
   })
   return handleResponse(response)
 }
@@ -193,17 +212,34 @@ export interface SaveSettingsResponse {
  */
 export async function updateSettings(
   profileId: number | "current",
-  settings: Omit<ProfileSettings, "z_offset">,
+  settings: ProfileSettings,
+  zOffset?: number | null,
 ): Promise<SaveSettingsResponse> {
-  // z_offset is read-only, so we don't send it when saving settings
+  const body: Record<string, unknown> = {
+    grid_size: settings.grid_size,
+    bed_temp: settings.bed_temp,
+    precision: settings.precision,
+  }
+  if (zOffset != null) body.z_offset = zOffset
   const response = await fetch(`${API_BASE}/${profileId}/settings`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      grid_size: settings.grid_size,
-      bed_temp: settings.bed_temp,
-      precision: settings.precision,
-    }),
+    body: JSON.stringify(body),
+  })
+  return handleResponse<SaveSettingsResponse>(response)
+}
+
+/**
+ * Update active z_offset by updating the settings (writes to printer.cfg)
+ */
+export async function updateActiveZOffset(
+  profileId: number | "current",
+  zOffset: number,
+): Promise<SaveSettingsResponse> {
+  const response = await fetch(`${API_BASE}/${profileId}/settings`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ z_offset: zOffset }),
   })
   return handleResponse<SaveSettingsResponse>(response)
 }

--- a/frontend/src/lib/stores/leveling.ts
+++ b/frontend/src/lib/stores/leveling.ts
@@ -11,32 +11,30 @@ export interface LevelingSettings {
   precision: number
 }
 
-export interface MeshProfile {
+/** Slot represents any mesh data entry: active, saved, or average */
+export interface Slot {
   id: number | "active" | "average"
   name: string
   date?: string
   data: number[][]
-  zOffset?: number // Only for the active mesh
+  zOffset?: number // undefined = legacy/unknown, number = known z_offset
 }
 
 export interface LevelingStore {
-  settings: LevelingSettings | null
-  activeMesh: MeshProfile | null
-  savedMeshes: MeshProfile[]
-  averageMesh: MeshProfile | null
+  settings?: LevelingSettings
+  activeSlot?: Slot
+  savedSlots: Slot[]
+  averageSlot?: Slot
   isLoading: boolean // For the initial page load
   isUpdating: boolean // For background updates after an action
   rebootNeeded: boolean
-  error: string | null
+  error?: string
 }
 
 // --- Helper Functions ---
 
 /**
  * Parses a flat mesh string (e.g., "0.1, 0.2, 0.3...") into a 2D number array.
- * @param meshString The raw mesh data string.
- * @param gridSize The size of the grid (e.g., 5 for a 5x5 mesh).
- * @returns A 2D array of numbers representing the mesh.
  */
 function parseMeshString(meshString: string, gridSize: number): number[][] {
   const flatData = meshString.split(",").map((s) => parseFloat(s.trim()))
@@ -49,12 +47,9 @@ function parseMeshString(meshString: string, gridSize: number): number[][] {
 
 /**
  * Applies precision rounding to mesh data, matching the C backend's apply_precision function.
- * @param meshData 2D array of mesh values.
- * @param precision The precision value (e.g., 0.01 means round to nearest 0.01).
  */
 function applyPrecision(meshData: number[][], precision: number): void {
   if (precision === 0.0) return
-
   for (let i = 0; i < meshData.length; i++) {
     for (let j = 0; j < meshData[i].length; j++) {
       meshData[i][j] = Math.round(meshData[i][j] / precision) * precision
@@ -63,61 +58,59 @@ function applyPrecision(meshData: number[][], precision: number): void {
 }
 
 /**
- * Calculates the average of a list of saved mesh profiles.
- * @param meshes An array of saved mesh profiles.
- * @param gridSize The size of the grid.
- * @param precision The precision value to apply to the averaged mesh (default: 0.01).
- * @returns A new MeshProfile representing the average, or null if no meshes are provided.
+ * Calculates the average slot from a list of saved slots.
+ * Only slots that have z_offset contribute to the z_offset average.
  */
-function calculateAverageMesh(
-  meshes: MeshProfile[],
+function calculateAverageSlot(
+  slots: Slot[],
   gridSize: number,
   precision: number = 0.01,
-): MeshProfile | null {
-  if (meshes.length === 0) return null
+): Slot | undefined {
+  if (slots.length === 0) return undefined
 
   const avgData = Array.from({ length: gridSize }, () =>
     Array(gridSize).fill(0),
   )
-  for (const mesh of meshes) {
+  for (const slot of slots) {
     for (let i = 0; i < gridSize; i++) {
       for (let j = 0; j < gridSize; j++) {
-        avgData[i][j] += mesh.data[i][j]
+        avgData[i][j] += slot.data[i][j]
       }
     }
   }
-
   for (let i = 0; i < gridSize; i++) {
     for (let j = 0; j < gridSize; j++) {
-      avgData[i][j] = avgData[i][j] / meshes.length
+      avgData[i][j] /= slots.length
     }
   }
 
-  // Apply precision rounding, matching the C backend behavior
   applyPrecision(avgData, precision)
 
-  return { id: "average", name: "Average", data: avgData }
+  // Average z_offset only from slots that have it; undefined if none do
+  const withZ = slots.filter((s) => s.zOffset !== undefined)
+  const avgZOffset =
+    withZ.length > 0
+      ? withZ.reduce((acc, s) => acc + s.zOffset!, 0) / withZ.length
+      : undefined
+
+  return { id: "average", name: "Average", data: avgData, zOffset: avgZOffset }
 }
 
 // --- Store ---
 
 function createLevelingStore() {
   const { subscribe, set, update } = writable<LevelingStore>({
-    settings: null,
-    activeMesh: null,
-    savedMeshes: [],
-    averageMesh: null,
+    savedSlots: [],
     isLoading: true,
     isUpdating: false,
     rebootNeeded: false,
-    error: null,
   })
 
   async function fetchData(initial = false) {
     if (initial) {
-      update((s) => ({ ...s, isLoading: true, error: null }))
+      update((s) => ({ ...s, isLoading: true, error: undefined }))
     } else {
-      update((s) => ({ ...s, isUpdating: true, error: null }))
+      update((s) => ({ ...s, isUpdating: true, error: undefined }))
     }
 
     try {
@@ -125,36 +118,37 @@ function createLevelingStore() {
       const status = await api.getProfile(selectedProfile)
       const gridSize = status.settings.grid_size
 
-      const activeMesh: MeshProfile = {
+      const activeSlot: Slot = {
         id: "active",
         name: "Active",
-        data: parseMeshString(status.active_mesh.mesh_data, gridSize),
-        zOffset: status.settings.z_offset, // z_offset comes from settings in the C backend
+        data: parseMeshString(status.active_slot.mesh_data, gridSize),
+        zOffset: status.active_slot.z_offset,
       }
 
-      const savedMeshes: MeshProfile[] = status.saved_meshes.map((sm) => ({
-        id: sm.id,
+      const savedSlots: Slot[] = status.saved_slots.map((sm) => ({
+        id: sm.id!,
         name: `Slot ${sm.id}`,
         date: sm.date,
         data: parseMeshString(sm.mesh_data, gridSize),
+        zOffset: sm.z_offset,
       }))
 
       const precision = status.settings.precision
-      const averageMesh = calculateAverageMesh(savedMeshes, gridSize, precision)
+      const averageSlot = calculateAverageSlot(savedSlots, gridSize, precision)
 
       set({
-        ...get(levelingStore), // Preserve existing state like rebootNeeded
+        ...get(levelingStore),
         settings: {
           gridSize: status.settings.grid_size,
           bedTemp: status.settings.bed_temp,
           precision: status.settings.precision,
         },
-        activeMesh,
-        savedMeshes,
-        averageMesh,
+        activeSlot,
+        savedSlots,
+        averageSlot,
         isLoading: false,
         isUpdating: false,
-        error: null,
+        error: undefined,
       })
     } catch (e: any) {
       update((s) => ({
@@ -171,7 +165,7 @@ function createLevelingStore() {
     try {
       const selectedProfile = get(profilesStore).selectedProfile
       await api.deleteSlot(selectedProfile, slotId)
-      await fetchData() // Refetch data to update the state
+      await fetchData()
     } catch (e: any) {
       update((s) => ({
         ...s,
@@ -192,34 +186,31 @@ function createLevelingStore() {
     update((s) => ({ ...s, isUpdating: true }))
     try {
       const selectedProfile = get(profilesStore).selectedProfile
-      const apiSettings: Omit<api.ProfileSettings, "z_offset"> = {
+      const apiSettings: api.ProfileSettings = {
         grid_size: settings.gridSize,
         bed_temp: settings.bedTemp,
         precision: settings.precision,
       }
       const response = await api.updateSettings(selectedProfile, apiSettings)
 
-      // Only set rebootNeeded for "current" profile (the one actually on the printer)
-      // Saved profiles can be edited without affecting the printer state
       if (response.grid_size_changed && selectedProfile === "current") {
         update((s) => ({ ...s, rebootNeeded: true }))
       }
 
-      // If precision changed, recalculate average mesh immediately if we have saved meshes
       if (
         precisionChanged &&
-        currentStore.savedMeshes.length > 0 &&
+        currentStore.savedSlots.length > 0 &&
         currentStore.settings
       ) {
-        const newAverageMesh = calculateAverageMesh(
-          currentStore.savedMeshes,
+        const newAverageSlot = calculateAverageSlot(
+          currentStore.savedSlots,
           currentStore.settings.gridSize,
           settings.precision,
         )
-        update((s) => ({ ...s, averageMesh: newAverageMesh }))
+        update((s) => ({ ...s, averageSlot: newAverageSlot }))
       }
 
-      await fetchData() // Refetch data to update the state
+      await fetchData()
       return response
     } catch (e: any) {
       update((s) => ({
@@ -236,11 +227,16 @@ function createLevelingStore() {
     try {
       const selectedProfile = get(profilesStore).selectedProfile
       const store = get(levelingStore)
-      if (!store.activeMesh) {
+      if (!store.activeSlot) {
         throw new Error("No active mesh to save")
       }
-      const meshData = store.activeMesh.data.flat().join(", ")
-      await api.saveSlot(selectedProfile, slotId, meshData)
+      const meshData = store.activeSlot.data.flat().join(", ")
+      await api.saveSlot(
+        selectedProfile,
+        slotId,
+        meshData,
+        store.activeSlot.zOffset,
+      )
       await fetchData()
     } catch (e: any) {
       update((s) => ({
@@ -256,8 +252,15 @@ function createLevelingStore() {
     update((s) => ({ ...s, isUpdating: true }))
     try {
       const selectedProfile = get(profilesStore).selectedProfile
+      const store = get(levelingStore)
+      const existingSlot = store.savedSlots.find((s) => s.id === slotId)
       const meshData = editedData.flat().join(", ")
-      await api.saveSlot(selectedProfile, slotId, meshData) // Re-use the same API endpoint
+      await api.saveSlot(
+        selectedProfile,
+        slotId,
+        meshData,
+        existingSlot?.zOffset,
+      )
       await fetchData()
     } catch (e: any) {
       update((s) => ({
@@ -274,12 +277,12 @@ function createLevelingStore() {
     try {
       const selectedProfile = get(profilesStore).selectedProfile
       const store = get(levelingStore)
-      const slot = store.savedMeshes.find((s) => s.id === slotId)
+      const slot = store.savedSlots.find((s) => s.id === slotId)
       if (!slot) {
         throw new Error(`Slot ${slotId} not found`)
       }
       const meshData = slot.data.flat().join(", ")
-      await api.updatePrinterMesh(selectedProfile, meshData)
+      await api.updatePrinterMesh(selectedProfile, meshData, slot.zOffset)
       await fetchData()
     } catch (e: any) {
       update((s) => ({
@@ -296,8 +299,7 @@ function createLevelingStore() {
     try {
       const selectedProfile = get(profilesStore).selectedProfile
       const store = get(levelingStore)
-      // Delete all slots individually since the backend doesn't support bulk delete
-      const deletePromises = store.savedMeshes.map((slot) => {
+      const deletePromises = store.savedSlots.map((slot) => {
         if (typeof slot.id === "number") {
           return api.deleteSlot(selectedProfile, slot.id)
         }
@@ -317,13 +319,14 @@ function createLevelingStore() {
 
   async function activateAverageMesh() {
     const store = get(levelingStore)
-    if (store.averageMesh) {
+    if (store.averageSlot) {
       update((s) => ({ ...s, isUpdating: true }))
       try {
         const selectedProfile = get(profilesStore).selectedProfile
         await api.updatePrinterMesh(
           selectedProfile,
-          store.averageMesh.data.flat().join(", "),
+          store.averageSlot.data.flat().join(", "),
+          store.averageSlot.zOffset,
         )
         await fetchData()
       } catch (e: any) {
@@ -334,6 +337,31 @@ function createLevelingStore() {
         }))
         throw e
       }
+    }
+  }
+
+  /**
+   * Update z_offset for a slot.
+   * - Active slot ("active"): updates via settings API (writes to printer.cfg)
+   * - Saved slot (number): partial update via slot API (writes line 2 of .txt file)
+   */
+  async function updateZOffset(slotId: number | "active", newZOffset: number) {
+    update((s) => ({ ...s, isUpdating: true }))
+    try {
+      const selectedProfile = get(profilesStore).selectedProfile
+      if (slotId === "active") {
+        await api.updateActiveZOffset(selectedProfile, newZOffset)
+      } else {
+        await api.updateSlotZOffset(selectedProfile, slotId, newZOffset)
+      }
+      await fetchData()
+    } catch (e: any) {
+      update((s) => ({
+        ...s,
+        isUpdating: false,
+        error: e.message || `Failed to update z_offset for slot ${slotId}.`,
+      }))
+      throw e
     }
   }
 
@@ -351,6 +379,7 @@ function createLevelingStore() {
     activateSlot,
     deleteAllSlots,
     activateAverageMesh,
+    updateZOffset,
   }
 }
 

--- a/frontend/src/routes/leveling/+page.svelte
+++ b/frontend/src/routes/leveling/+page.svelte
@@ -330,8 +330,21 @@
     editingZOffsetValue = ""
   }
 
-  function formatZOffset(zOffset?: number): string {
-    return zOffset !== undefined ? `z: ${zOffset.toFixed(4)}mm` : "z: —"
+  function formatZOffset(zOffset?: number, precision?: number): string {
+    if (zOffset === undefined) return "z: —"
+    // Number of decimal places to round to (derived from precision step)
+    // e.g. 0.01 → 2, 0.005 → 3, 0.001 → 3
+    const decimals =
+      precision !== undefined && precision > 0
+        ? Math.max(0, -Math.floor(Math.log10(precision)))
+        : 4
+    // Round to nearest precision step
+    const rounded =
+      precision !== undefined && precision > 0
+        ? Math.round(zOffset / precision) * precision
+        : zOffset
+    // toFixed for rounding, then parseFloat strips trailing zeros
+    return `z: ${parseFloat(rounded.toFixed(decimals))}mm`
   }
 
   // Reactive label for mesh based on selection
@@ -470,7 +483,10 @@
                         $levelingStore.activeSlot?.zOffset,
                       )}
                   >
-                    {formatZOffset($levelingStore.activeSlot.zOffset)}
+                    {formatZOffset(
+                      $levelingStore.activeSlot.zOffset,
+                      $levelingStore.settings?.precision,
+                    )}
                     <FontAwesomeIcon icon={faPencilAlt} class="edit-icon" />
                   </button>
                 {/if}
@@ -509,7 +525,10 @@
                 </span>
                 <!-- Average z-offset is read-only -->
                 <span class="zoffset-label readonly">
-                  {formatZOffset($levelingStore.averageSlot.zOffset)}
+                  {formatZOffset(
+                    $levelingStore.averageSlot.zOffset,
+                    $levelingStore.settings?.precision,
+                  )}
                 </span>
                 <div class="button-group">
                   <button
@@ -572,7 +591,10 @@
                     typeof slot.id === "number" &&
                     startEditZOffset(slot.id, slot.zOffset)}
                 >
-                  {formatZOffset(slot.zOffset)}
+                  {formatZOffset(
+                    slot.zOffset,
+                    $levelingStore.settings?.precision,
+                  )}
                   <FontAwesomeIcon icon={faPencilAlt} class="edit-icon" />
                 </button>
               {/if}

--- a/frontend/src/routes/leveling/+page.svelte
+++ b/frontend/src/routes/leveling/+page.svelte
@@ -17,12 +17,13 @@
     faFileMedical,
     faHdd,
     faUser,
+    faPencilAlt,
   } from "@fortawesome/free-solid-svg-icons"
   import { get, type Unsubscriber } from "svelte/store"
   import { onDestroy } from "svelte"
   import { levelingStore } from "$lib/stores/leveling"
   import { profilesStore } from "$lib/stores/profiles"
-  import type { MeshProfile } from "$lib/stores/leveling"
+  import type { Slot } from "$lib/stores/leveling"
   import Spinner from "$lib/components/Spinner.svelte"
   import InfoModal from "$lib/components/InfoModal.svelte"
   import { toast } from "svelte-sonner"
@@ -50,18 +51,26 @@
   let isSaveAsModalOpen = false
   let isProfileManagerModalOpen = false
 
-  $: if ($levelingStore.activeMesh) {
-    const activeDataString = JSON.stringify($levelingStore.activeMesh.data)
-    const foundSlot = $levelingStore.savedMeshes.find(
+  // z-offset inline editing state
+  let editingZOffsetSlotId: number | "active" | null = null
+  let editingZOffsetValue = ""
+
+  function focusOnMount(node: HTMLElement) {
+    node.focus()
+  }
+
+  $: if ($levelingStore.activeSlot) {
+    const activeDataString = JSON.stringify($levelingStore.activeSlot.data)
+    const foundSlot = $levelingStore.savedSlots.find(
       (s) => JSON.stringify(s.data) === activeDataString,
     )
     if (foundSlot) {
       activeSlotId = foundSlot.id
     } else {
-      const averageMesh = $levelingStore.averageMesh
+      const averageSlot = $levelingStore.averageSlot
       if (
-        averageMesh &&
-        JSON.stringify(averageMesh.data) === activeDataString
+        averageSlot &&
+        JSON.stringify(averageSlot.data) === activeDataString
       ) {
         activeSlotId = "average"
       } else {
@@ -84,45 +93,44 @@
     if (store.settings && !store.isUpdating) {
       localSettings = { ...store.settings }
     }
-    // Initialize visualized data with the active mesh from the store
-    if (store.activeMesh && visualizedSlotId === null) {
-      visualizedMeshData = store.activeMesh.data
+    // Initialize visualized data with the active slot from the store
+    if (store.activeSlot && visualizedSlotId === null) {
+      visualizedMeshData = store.activeSlot.data
       visualizedSlotId = "active"
     }
   })
   onDestroy(unsubLeveling)
 
-  // Reactive block to handle cases where the visualized mesh is deleted from the store
+  // Reactive block to handle cases where the visualized slot is deleted from the store
   $: if (
-    $levelingStore.activeMesh &&
+    $levelingStore.activeSlot &&
     visualizedSlotId &&
     visualizedSlotId !== "active" &&
     visualizedSlotId !== "average" &&
-    !$levelingStore.savedMeshes.find((s) => s.id === visualizedSlotId)
+    !$levelingStore.savedSlots.find((s) => s.id === visualizedSlotId)
   ) {
-    visualizeSlot($levelingStore.activeMesh)
+    visualizeSlot($levelingStore.activeSlot)
   }
 
-  // Ensure the visualizer updates when the active mesh data changes from the store
-  $: if (visualizedSlotId === "active" && $levelingStore.activeMesh) {
-    visualizedMeshData = $levelingStore.activeMesh.data
+  // Ensure the visualizer updates when the active slot data changes
+  $: if (visualizedSlotId === "active" && $levelingStore.activeSlot) {
+    visualizedMeshData = $levelingStore.activeSlot.data
   }
 
-  // Ensure the visualizer updates when the average mesh data changes from the store
-  $: if (visualizedSlotId === "average" && $levelingStore.averageMesh) {
-    visualizedMeshData = $levelingStore.averageMesh.data
+  // Ensure the visualizer updates when the average slot data changes
+  $: if (visualizedSlotId === "average" && $levelingStore.averageSlot) {
+    visualizedMeshData = $levelingStore.averageSlot.data
   }
 
   // --- UI Functions ---
 
   function enterEditMode() {
-    // Create a deep copy of the data for editing
     editedMeshData = JSON.parse(JSON.stringify(visualizedMeshData))
-    visualizedSlotId = null // Remove visualized state
+    visualizedSlotId = null
     isEditing = true
   }
 
-  function visualizeSlot(slot: MeshProfile) {
+  function visualizeSlot(slot: Slot) {
     if (slot) {
       if (isEditing) {
         if (
@@ -139,7 +147,7 @@
     }
   }
 
-  function activateSlot(slotToActivate: MeshProfile) {
+  function activateSlot(slotToActivate: Slot) {
     if (typeof slotToActivate.id === "number") {
       levelingStore.activateSlot(slotToActivate.id)
     } else if (slotToActivate.id === "average") {
@@ -150,8 +158,6 @@
   async function handleSaveSettings() {
     if (!$levelingStore.settings) return
 
-    // Only show grid size change warning for "current" profile (the one on the printer)
-    // Saved profiles can be edited without requiring a reboot
     if (
       $profilesStore.selectedProfile === "current" &&
       localSettings.gridSize !== $levelingStore.settings.gridSize
@@ -181,7 +187,6 @@
     try {
       const response = await levelingStore.saveSettings(localSettings)
       modalState = "closed"
-      // Only show reboot required dialog for "current" profile
       if (
         response.grid_size_changed &&
         $profilesStore.selectedProfile === "current"
@@ -210,7 +215,6 @@
       const response = await fetch("/api/system/reboot", { method: "POST" })
       if (response.ok) {
         toast.success("Printer is rebooting...")
-        // Close the modal
         modalState = "closed"
       } else {
         throw new Error("Reboot request failed")
@@ -230,20 +234,20 @@
         await levelingStore.saveEditedMesh(slotId, editedMeshData)
         isEditing = false
         toast.success(`Mesh saved to slot ${slotId}`)
-        const savedMesh = get(levelingStore).savedMeshes.find(
+        const savedSlot = get(levelingStore).savedSlots.find(
           (s) => s.id === slotId,
         )
-        if (savedMesh) {
-          visualizeSlot(savedMesh)
+        if (savedSlot) {
+          visualizeSlot(savedSlot)
         }
       } else {
         await levelingStore.saveActiveMesh(slotId)
         toast.success(`Active mesh saved to slot ${slotId}`)
-        const savedMesh = get(levelingStore).savedMeshes.find(
+        const savedSlot = get(levelingStore).savedSlots.find(
           (s) => s.id === slotId,
         )
-        if (savedMesh) {
-          visualizeSlot(savedMesh)
+        if (savedSlot) {
+          visualizeSlot(savedSlot)
         }
       }
     } catch (error) {
@@ -276,7 +280,6 @@
       await profilesStore.saveAs(sourceId, target, name)
 
       if (target === "current") {
-        // Show reboot modal when profile is applied to current
         modalInfo = {
           title: "Reboot Required",
           message:
@@ -294,16 +297,48 @@
         toast.success("Profile saved successfully")
       }
 
-      // Refetch leveling data if we're still on the same profile
       await levelingStore.fetchData()
     } catch (e: any) {
       toast.error(e.message || "Failed to save profile")
     }
   }
 
+  // --- z-offset inline editing ---
+
+  function startEditZOffset(slotId: number | "active", currentValue?: number) {
+    editingZOffsetSlotId = slotId
+    editingZOffsetValue = currentValue !== undefined ? String(currentValue) : ""
+  }
+
+  async function commitZOffset() {
+    if (editingZOffsetSlotId === null) return
+    const parsed = parseFloat(editingZOffsetValue)
+    if (!isNaN(parsed)) {
+      try {
+        await levelingStore.updateZOffset(editingZOffsetSlotId, parsed)
+        toast.success("Z-offset updated")
+      } catch {
+        toast.error("Failed to update z-offset")
+      }
+    }
+    editingZOffsetSlotId = null
+    editingZOffsetValue = ""
+  }
+
+  function cancelEditZOffset() {
+    editingZOffsetSlotId = null
+    editingZOffsetValue = ""
+  }
+
+  function formatZOffset(zOffset?: number): string {
+    return zOffset !== undefined ? `z: ${zOffset.toFixed(4)}mm` : "z: —"
+  }
+
   // Reactive label for mesh based on selection
   $: meshLabel =
-    $profilesStore.selectedProfile === "current" ? "Active Mesh" : "Saved Mesh"
+    $profilesStore.selectedProfile === "current"
+      ? "Active Mesh"
+      : "Profile Mesh"
 
   // Watch for profile changes and refetch data
   $: if ($profilesStore.selectedProfile) {
@@ -405,15 +440,40 @@
             <h3 class="card-title"><FontAwesomeIcon icon={faTh} /> Bed Mesh</h3>
           </svelte:fragment>
           <div class="mesh-list">
-            {#if $levelingStore.activeMesh}
+            {#if $levelingStore.activeSlot}
               <div
                 class="mesh-item"
                 class:active={visualizedSlotId === "active"}
               >
-                <span
-                  >{meshLabel} (Z-Offset: {$levelingStore.activeMesh
-                    .zOffset})</span
-                >
+                <span>{meshLabel}</span>
+                <!-- z-offset display / inline edit for active slot -->
+                {#if editingZOffsetSlotId === "active"}
+                  <input
+                    class="zoffset-input"
+                    type="number"
+                    step="0.0001"
+                    bind:value={editingZOffsetValue}
+                    on:keydown={(e) => {
+                      if (e.key === "Enter") commitZOffset()
+                      if (e.key === "Escape") cancelEditZOffset()
+                    }}
+                    on:blur={commitZOffset}
+                    use:focusOnMount
+                  />
+                {:else}
+                  <button
+                    class="zoffset-label"
+                    title="Click to edit z-offset"
+                    on:click={() =>
+                      startEditZOffset(
+                        "active",
+                        $levelingStore.activeSlot?.zOffset,
+                      )}
+                  >
+                    {formatZOffset($levelingStore.activeSlot.zOffset)}
+                    <FontAwesomeIcon icon={faPencilAlt} class="edit-icon" />
+                  </button>
+                {/if}
                 <div class="button-group">
                   <button
                     class="small primary"
@@ -424,8 +484,8 @@
                   <button
                     class="small"
                     on:click={() =>
-                      $levelingStore.activeMesh &&
-                      visualizeSlot($levelingStore.activeMesh)}
+                      $levelingStore.activeSlot &&
+                      visualizeSlot($levelingStore.activeSlot)}
                     disabled={visualizedSlotId === "active"}
                   >
                     <FontAwesomeIcon icon={faEye} />
@@ -436,7 +496,7 @@
             {/if}
 
             <!-- Average Mesh Special Slot -->
-            {#if $levelingStore.averageMesh}
+            {#if $levelingStore.averageSlot}
               <div
                 class="mesh-item"
                 class:active={visualizedSlotId === "average"}
@@ -446,6 +506,10 @@
                   {#if activeSlotId === "average"}
                     <span class="active-label">active</span>
                   {/if}
+                </span>
+                <!-- Average z-offset is read-only -->
+                <span class="zoffset-label readonly">
+                  {formatZOffset($levelingStore.averageSlot.zOffset)}
                 </span>
                 <div class="button-group">
                   <button
@@ -457,8 +521,8 @@
                   <button
                     class="small"
                     on:click={() =>
-                      $levelingStore.averageMesh &&
-                      visualizeSlot($levelingStore.averageMesh)}
+                      $levelingStore.averageSlot &&
+                      visualizeSlot($levelingStore.averageSlot)}
                     disabled={visualizedSlotId === "average"}
                     ><FontAwesomeIcon icon={faEye} />
                     Visualize
@@ -478,7 +542,7 @@
           </h3>
         </svelte:fragment>
         <div class="mesh-list">
-          {#each $levelingStore.savedMeshes as slot (slot.id)}
+          {#each $levelingStore.savedSlots as slot (slot.id)}
             <div class="mesh-item" class:active={slot.id === visualizedSlotId}>
               <span class="slot-name">
                 {slot.name}
@@ -486,6 +550,32 @@
                   <span class="active-label">active</span>
                 {/if}
               </span>
+              <!-- z-offset inline edit for saved slots -->
+              {#if editingZOffsetSlotId === slot.id}
+                <input
+                  class="zoffset-input"
+                  type="number"
+                  step="0.0001"
+                  bind:value={editingZOffsetValue}
+                  on:keydown={(e) => {
+                    if (e.key === "Enter") commitZOffset()
+                    if (e.key === "Escape") cancelEditZOffset()
+                  }}
+                  on:blur={commitZOffset}
+                  use:focusOnMount
+                />
+              {:else}
+                <button
+                  class="zoffset-label"
+                  title="Click to edit z-offset"
+                  on:click={() =>
+                    typeof slot.id === "number" &&
+                    startEditZOffset(slot.id, slot.zOffset)}
+                >
+                  {formatZOffset(slot.zOffset)}
+                  <FontAwesomeIcon icon={faPencilAlt} class="edit-icon" />
+                </button>
+              {/if}
               <div class="button-group">
                 <button
                   class="small"
@@ -651,7 +741,6 @@
     align-items: flex-end;
   }
   .settings-form .button-group {
-    /* This allows the button to align nicely with the inputs */
     padding-bottom: 0;
   }
 
@@ -722,18 +811,25 @@
   }
 
   .mesh-item {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
     align-items: center;
     padding: 0.5rem;
     border-radius: 5px;
     background-color: var(--background-color);
     border: 1px solid transparent;
     transition: all 0.2s;
+    column-gap: 0.5rem;
+    row-gap: 0.15rem;
   }
   .mesh-item.active {
     border-color: var(--accent-color);
     background-color: var(--card-background-color);
+  }
+  .mesh-item .button-group {
+    grid-column: 2;
+    grid-row: 1 / span 2;
   }
 
   .active-label {
@@ -750,6 +846,38 @@
   .slot-name {
     display: flex;
     align-items: center;
+  }
+
+  .zoffset-label {
+    font-size: 0.75em;
+    color: var(--text-muted-color, #888);
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font-weight: normal;
+    text-align: left;
+    justify-self: start;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+  .zoffset-label.readonly {
+    cursor: default;
+  }
+  .zoffset-label :global(.edit-icon) {
+    opacity: 0.4;
+    font-size: 0.85em;
+  }
+  .zoffset-label:hover :global(.edit-icon) {
+    opacity: 1;
+  }
+
+  .zoffset-input {
+    width: 8rem;
+    font-size: 0.8em;
+    padding: 0.15rem 0.3rem;
+    justify-self: start;
   }
 
   @media (max-width: 900px) {

--- a/frontend/test/mocks/levelingApi.ts
+++ b/frontend/test/mocks/levelingApi.ts
@@ -8,25 +8,21 @@ export interface ProfileSettings {
   grid_size: number
   bed_temp: number
   precision: number
-  z_offset: number // z_offset is returned in settings by the C backend
 }
 
-export interface MeshData {
+export interface Slot {
+  id?: number // present for saved slots; absent for active_slot
+  date?: string // present for saved slots
   mesh_data: string
-}
-
-export interface SavedMesh {
-  id: number
-  date: string
-  mesh_data: string
+  z_offset?: number // undefined = legacy slot without z_offset
 }
 
 export interface ProfileDetails {
   id: number | "current"
   name?: string // Optional for "current" profile
   settings: ProfileSettings
-  active_mesh: MeshData
-  saved_meshes: SavedMesh[]
+  active_slot: Slot
+  saved_slots: Slot[]
   loaded_from?: number // Optional, indicates which profile was last applied to Current
 }
 
@@ -95,36 +91,41 @@ const mockCurrentProfile: ProfileDetails = {
     grid_size: 5,
     bed_temp: 60,
     precision: 0.01,
-    z_offset: 1.443, // z_offset is in settings
   },
-  active_mesh: {
+  active_slot: {
     mesh_data: generateSlopedMeshData(5, "y-positive"),
+    z_offset: 1.443,
   },
-  saved_meshes: [
+  saved_slots: [
     {
       id: 1,
       date: "2025-11-12 10:30:00",
       mesh_data: generateSlopedMeshData(5, "x-positive"),
+      z_offset: 1.443,
     },
     {
       id: 2,
       date: "2025-11-11 15:45:00",
       mesh_data: generateSlopedMeshData(5, "x-negative"),
+      z_offset: 1.51,
     },
     {
       id: 3,
       date: "2025-11-12 10:30:00",
       mesh_data: generateSlopedMeshData(5, "y-positive"),
+      z_offset: 1.38,
     },
     {
       id: 4,
       date: "2025-11-11 15:45:00",
       mesh_data: generateSlopedMeshData(5, "y-negative"),
+      // no z_offset = legacy slot
     },
     {
       id: 10,
       date: "2025-11-12 22:45:00",
       mesh_data: generateSlopedMeshData(5, "flat"),
+      z_offset: 1.42,
     },
   ],
 }
@@ -142,19 +143,22 @@ const mockProfiles: Map<number, ProfileDetails> = new Map([
         precision: 0.01,
         z_offset: 1.2,
       },
-      active_mesh: {
+      active_slot: {
         mesh_data: generateSlopedMeshData(5, "x-positive"),
+        z_offset: 1.2,
       },
-      saved_meshes: [
+      saved_slots: [
         {
           id: 1,
           date: "2025-11-10 09:15:00",
           mesh_data: generateSlopedMeshData(5, "flat"),
+          z_offset: 1.2,
         },
         {
           id: 2,
           date: "2025-11-09 14:30:00",
           mesh_data: generateSlopedMeshData(5, "y-positive"),
+          // no z_offset = legacy slot
         },
       ],
     },
@@ -170,19 +174,22 @@ const mockProfiles: Map<number, ProfileDetails> = new Map([
         precision: 0.02,
         z_offset: 0.8,
       },
-      active_mesh: {
+      active_slot: {
         mesh_data: generateSlopedMeshData(5, "x-negative"),
+        z_offset: 0.8,
       },
-      saved_meshes: [
+      saved_slots: [
         {
           id: 1,
           date: "2025-11-08 11:45:00",
           mesh_data: generateSlopedMeshData(5, "y-negative"),
+          z_offset: 0.8,
         },
         {
           id: 3,
           date: "2025-11-07 16:20:00",
           mesh_data: generateSlopedMeshData(5, "flat"),
+          z_offset: 0.79,
         },
       ],
     },
@@ -198,14 +205,16 @@ const mockProfiles: Map<number, ProfileDetails> = new Map([
         precision: 0.005,
         z_offset: 1.0,
       },
-      active_mesh: {
+      active_slot: {
         mesh_data: generateSlopedMeshData(5, "flat"),
+        z_offset: 1.0,
       },
-      saved_meshes: [
+      saved_slots: [
         {
           id: 1,
           date: "2025-11-06 13:10:00",
           mesh_data: generateSlopedMeshData(5, "x-positive"),
+          z_offset: 1.0,
         },
       ],
     },
@@ -254,12 +263,12 @@ export async function getProfile(
               grid_size: 5,
               bed_temp: 60,
               precision: 0.01,
+            },
+            active_slot: {
+              mesh_data: generateSlopedMeshData(5, "flat"),
               z_offset: 0,
             },
-            active_mesh: {
-              mesh_data: generateSlopedMeshData(5, "flat"),
-            },
-            saved_meshes: [],
+            saved_slots: [],
           })
         }
       }
@@ -284,9 +293,9 @@ export async function deleteSlot(
     )
   }
 
-  const index = profile.saved_meshes.findIndex((mesh) => mesh.id === slotId)
+  const index = profile.saved_slots.findIndex((slot) => slot.id === slotId)
   if (index !== -1) {
-    profile.saved_meshes.splice(index, 1)
+    profile.saved_slots.splice(index, 1)
     return new Promise((resolve) =>
       setTimeout(
         () =>
@@ -338,15 +347,11 @@ export async function updateSettings(
   let gridSizeChanged = false
   if (settings.grid_size !== profile.settings.grid_size) {
     gridSizeChanged = true
-    profile.saved_meshes = []
+    profile.saved_slots = []
     const newSize = settings.grid_size * settings.grid_size
-    profile.active_mesh.mesh_data = Array(newSize).fill("0.000000").join(", ")
+    profile.active_slot.mesh_data = Array(newSize).fill("0.000000").join(", ")
   }
-  // Update settings but preserve z_offset (it's read-only)
-  profile.settings = {
-    ...settings,
-    z_offset: profile.settings.z_offset,
-  }
+  profile.settings = { ...settings }
 
   const response: SaveSettingsResponse = {
     status: "success",
@@ -360,6 +365,7 @@ export async function saveSlot(
   profileId: number | "current",
   slotId: number,
   meshData: string,
+  zOffset?: number,
 ): Promise<{ status: string; message: string }> {
   console.log(`Mock API: Saving mesh to slot ${slotId} in profile ${profileId}`)
 
@@ -374,25 +380,17 @@ export async function saveSlot(
     )
   }
 
-  if (!profile.active_mesh) {
-    return new Promise((resolve) =>
-      setTimeout(
-        () => resolve({ status: "error", message: "No active mesh to save." }),
-        500,
-      ),
-    )
-  }
-  const existingSlot = profile.saved_meshes.find((mesh) => mesh.id === slotId)
+  const existingSlot = profile.saved_slots.find((slot) => slot.id === slotId)
   if (existingSlot) {
-    // Overwrite existing slot
     existingSlot.mesh_data = meshData
     existingSlot.date = new Date().toISOString().slice(0, 19).replace("T", " ")
+    if (zOffset !== undefined) existingSlot.z_offset = zOffset
   } else {
-    // Add new slot
-    profile.saved_meshes.push({
+    profile.saved_slots.push({
       id: slotId,
       date: new Date().toISOString().slice(0, 19).replace("T", " "),
       mesh_data: meshData,
+      z_offset: zOffset,
     })
   }
   return new Promise((resolve) =>
@@ -407,9 +405,85 @@ export async function saveSlot(
   )
 }
 
+export async function updateSlotZOffset(
+  profileId: number | "current",
+  slotId: number,
+  zOffset: number,
+): Promise<{ status: string; message: string }> {
+  console.log(
+    `Mock API: Updating z_offset for slot ${slotId} in profile ${profileId}`,
+  )
+
+  const profile =
+    profileId === "current" ? mockCurrentProfile : mockProfiles.get(profileId)
+  if (!profile) {
+    return new Promise((resolve) =>
+      setTimeout(
+        () => resolve({ status: "error", message: "Profile not found." }),
+        500,
+      ),
+    )
+  }
+
+  const existingSlot = profile.saved_slots.find((slot) => slot.id === slotId)
+  if (existingSlot) {
+    existingSlot.z_offset = zOffset
+    return new Promise((resolve) =>
+      setTimeout(
+        () => resolve({ status: "success", message: "Z-offset updated." }),
+        500,
+      ),
+    )
+  }
+  return new Promise((resolve) =>
+    setTimeout(
+      () => resolve({ status: "error", message: "Slot not found." }),
+      500,
+    ),
+  )
+}
+
+export async function updateActiveZOffset(
+  profileId: number | "current",
+  zOffset: number,
+): Promise<SaveSettingsResponse> {
+  console.log(`Mock API: Updating active z_offset for profile ${profileId}`)
+
+  const profile =
+    profileId === "current" ? mockCurrentProfile : mockProfiles.get(profileId)
+  if (!profile) {
+    return new Promise((resolve) =>
+      setTimeout(
+        () =>
+          resolve({
+            status: "error",
+            message: "Profile not found.",
+            grid_size_changed: false,
+          }),
+        500,
+      ),
+    )
+  }
+
+  profile.active_slot.z_offset = zOffset
+
+  return new Promise((resolve) =>
+    setTimeout(
+      () =>
+        resolve({
+          status: "success",
+          message: "Z-offset updated.",
+          grid_size_changed: false,
+        }),
+      500,
+    ),
+  )
+}
+
 export async function updatePrinterMesh(
   profileId: number | "current",
   meshData: string,
+  zOffset?: number,
 ): Promise<{ status: string; message: string }> {
   console.log(`Mock API: Updating printer mesh for profile ${profileId}`)
 
@@ -424,7 +498,10 @@ export async function updatePrinterMesh(
     )
   }
 
-  profile.active_mesh.mesh_data = meshData
+  profile.active_slot.mesh_data = meshData
+  if (zOffset !== undefined) {
+    profile.active_slot.z_offset = zOffset
+  }
   return new Promise((resolve) =>
     setTimeout(
       () => resolve({ status: "success", message: "Mesh content activated." }),
@@ -438,7 +515,7 @@ export async function deleteAllMeshSlots(): Promise<{
   message: string
 }> {
   console.log(`Mock API: Deleting all mesh slots`)
-  mockCurrentProfile.saved_meshes = []
+  mockCurrentProfile.saved_slots = []
   return new Promise((resolve) =>
     setTimeout(
       () => resolve({ status: "success", message: "All mesh slots deleted." }),
@@ -455,7 +532,6 @@ export async function createProfile(
     `Mock API: Creating profile from source ${sourceId} with name "${name}"`,
   )
 
-  // Get source profile data
   let sourceProfile: ProfileDetails
   if (sourceId === "current") {
     sourceProfile = mockCurrentProfile
@@ -476,17 +552,20 @@ export async function createProfile(
     sourceProfile = profile
   }
 
-  // Create new profile with copied data
   const newId = nextProfileId++
   const newProfile: ProfileDetails = {
     id: newId,
     name,
     settings: { ...sourceProfile.settings },
-    active_mesh: { mesh_data: sourceProfile.active_mesh.mesh_data },
-    saved_meshes: sourceProfile.saved_meshes.map((sm) => ({
+    active_slot: {
+      mesh_data: sourceProfile.active_slot.mesh_data,
+      z_offset: sourceProfile.active_slot.z_offset,
+    },
+    saved_slots: sourceProfile.saved_slots.map((sm) => ({
       id: sm.id,
       date: sm.date,
       mesh_data: sm.mesh_data,
+      z_offset: sm.z_offset,
     })),
   }
 
@@ -536,7 +615,6 @@ export async function deleteProfileById(
   const index = mockProfileList.profiles.findIndex((p) => p.id === id)
   if (index !== -1) {
     mockProfileList.profiles.splice(index, 1)
-    // Clear loaded_from if it matches the deleted profile
     if (mockProfileList.loaded_from === id) {
       mockProfileList.loaded_from = undefined
       mockCurrentProfile.loaded_from = undefined
@@ -565,7 +643,6 @@ export async function saveAsProfile(
     `Mock API: Saving profile ${sourceId} to target ${target}${name ? ` with name "${name}"` : ""}`,
   )
 
-  // Validate illegal operations
   if (sourceId === "current" && target === "current") {
     return new Promise((resolve) =>
       setTimeout(
@@ -608,7 +685,6 @@ export async function saveAsProfile(
   }
 
   if (target === "current") {
-    // Apply profile to current
     if (typeof sourceId === "number") {
       mockProfileList.loaded_from = sourceId
       mockCurrentProfile.loaded_from = sourceId
@@ -625,7 +701,6 @@ export async function saveAsProfile(
     )
   }
 
-  // Overwrite existing profile
   return new Promise((resolve) =>
     setTimeout(
       () =>
@@ -640,7 +715,6 @@ export async function saveAsProfile(
 
 export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
   return (req, res, next) => {
-    // Handle new profiles API endpoints
     if (req.url?.startsWith("/api/profiles")) {
       res.setHeader("Content-Type", "application/json")
 
@@ -652,7 +726,7 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
         return
       }
 
-      // GET /api/profiles/current - Get current profile details
+      // GET /api/profiles/current
       if (req.method === "GET" && req.url === "/api/profiles/current") {
         getProfile("current").then((data) => {
           res.end(JSON.stringify(data))
@@ -660,7 +734,7 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
         return
       }
 
-      // GET /api/profiles/{id} - Get specific profile details
+      // GET /api/profiles/{id}
       const getProfileMatch = req.url.match(/^\/api\/profiles\/(\d+)$/)
       if (req.method === "GET" && getProfileMatch) {
         const profileId = parseInt(getProfileMatch[1], 10)
@@ -712,7 +786,7 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
         return
       }
 
-      // PUT /api/profiles/current/slots/{id}
+      // PUT /api/profiles/{id}/slots/{n}
       const putSlotMatch = req.url.match(
         /^\/api\/profiles\/(current|\d+)\/slots\/(\d+)$/,
       )
@@ -727,16 +801,34 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
           body += chunk.toString()
         })
         req.on("end", () => {
-          const { mesh_data } = JSON.parse(body)
-          saveSlot(profileId, slotId, mesh_data).then((response) => {
-            res.statusCode = response.status === "success" ? 200 : 400
-            res.end(JSON.stringify(response))
-          })
+          const parsed = JSON.parse(body)
+          const { mesh_data, z_offset } = parsed
+          if (mesh_data) {
+            saveSlot(profileId, slotId, mesh_data, z_offset).then(
+              (response) => {
+                res.statusCode = response.status === "success" ? 200 : 400
+                res.end(JSON.stringify(response))
+              },
+            )
+          } else if (z_offset !== undefined) {
+            updateSlotZOffset(profileId, slotId, z_offset).then((response) => {
+              res.statusCode = response.status === "success" ? 200 : 400
+              res.end(JSON.stringify(response))
+            })
+          } else {
+            res.statusCode = 400
+            res.end(
+              JSON.stringify({
+                status: "error",
+                message: "Missing mesh_data or z_offset.",
+              }),
+            )
+          }
         })
         return
       }
 
-      // PUT /api/profiles/current/printer-mesh
+      // PUT /api/profiles/{id}/printer-mesh
       const putPrinterMeshMatch = req.url.match(
         /^\/api\/profiles\/(current|\d+)\/printer-mesh$/,
       )
@@ -750,8 +842,8 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
           body += chunk.toString()
         })
         req.on("end", () => {
-          const { mesh_data } = JSON.parse(body)
-          updatePrinterMesh(profileId, mesh_data).then((response) => {
+          const { mesh_data, z_offset } = JSON.parse(body)
+          updatePrinterMesh(profileId, mesh_data, z_offset).then((response) => {
             res.statusCode = response.status === "success" ? 200 : 400
             res.end(JSON.stringify(response))
           })
@@ -759,7 +851,7 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
         return
       }
 
-      // DELETE /api/profiles/current/slots/{id}
+      // DELETE /api/profiles/{id}/slots/{n}
       const deleteSlotMatch = req.url.match(
         /^\/api\/profiles\/(current|\d+)\/slots\/(\d+)$/,
       )
@@ -776,7 +868,7 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
         return
       }
 
-      // PUT /api/profiles/{id} - Update profile metadata
+      // PUT /api/profiles/{id}
       const putProfileMatch = req.url.match(/^\/api\/profiles\/(\d+)$/)
       if (req.method === "PUT" && putProfileMatch) {
         const profileId = parseInt(putProfileMatch[1], 10)
@@ -794,7 +886,7 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
         return
       }
 
-      // DELETE /api/profiles/{id} - Delete profile
+      // DELETE /api/profiles/{id}
       const deleteProfileMatch = req.url.match(/^\/api\/profiles\/(\d+)$/)
       if (req.method === "DELETE" && deleteProfileMatch) {
         const profileId = parseInt(deleteProfileMatch[1], 10)
@@ -805,7 +897,7 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
         return
       }
 
-      // POST /api/profiles/{id}/save-as - Save profile to target
+      // POST /api/profiles/{id}/save-as
       const saveAsMatch = req.url.match(
         /^\/api\/profiles\/(current|\d+)\/save-as$/,
       )
@@ -829,7 +921,7 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
       }
     }
 
-    // Fallback for old /api/leveling endpoints (for backward compatibility during transition)
+    // Fallback for old /api/leveling endpoints
     if (req.url?.startsWith("/api/leveling")) {
       res.setHeader("Content-Type", "application/json")
 
@@ -839,8 +931,6 @@ export function createLevelingApiMiddleware(): Connect.NextHandleFunction {
         })
         return
       }
-
-      // Other old endpoints can redirect to new ones if needed
     }
 
     next()

--- a/src/api/helpers.c
+++ b/src/api/helpers.c
@@ -364,7 +364,7 @@ int read_slots_json(const char *slots_dir, char *buffer, int buffer_size, int *l
         if (z_offset_line[0] != '\0') {
           char *end;
           double z_offset_val = strtod(z_offset_line, &end);
-          if (end != z_offset_line) {
+          if (end != z_offset_line && *end == '\0') {
             *len += snprintf(buffer + *len, buffer_size - *len,
                             "{\"id\": %d, \"date\": \"%s\", \"mesh_data\": \"%s\", \"z_offset\": %.4f}",
                             i, date_buf, mesh_data, z_offset_val);

--- a/src/api/helpers.c
+++ b/src/api/helpers.c
@@ -346,16 +346,38 @@ int read_slots_json(const char *slots_dir, char *buffer, int buffer_size, int *l
           *len += snprintf(buffer + *len, buffer_size - *len, ",");
         }
         char mesh_data[4096] = {0};
-        fread(mesh_data, 1, sizeof(mesh_data) - 1, file);
+        char z_offset_line[64] = {0};
+        // Line 1: mesh CSV
+        if (fgets(mesh_data, sizeof(mesh_data) - 1, file) != NULL) {
+          trim_trailing_whitespace(mesh_data);
+        }
+        // Line 2: optional z_offset
+        if (fgets(z_offset_line, sizeof(z_offset_line) - 1, file) != NULL) {
+          trim_trailing_whitespace(z_offset_line);
+        }
         fclose(file);
-        trim_trailing_whitespace(mesh_data);
 
         char date_buf[32];
         strftime(date_buf, sizeof(date_buf), "%Y-%m-%d %H:%M:%S", localtime(&st.st_mtime));
 
-        *len += snprintf(buffer + *len, buffer_size - *len,
-                        "{\"id\": %d, \"date\": \"%s\", \"mesh_data\": \"%s\"}",
-                        i, date_buf, mesh_data);
+        // Include z_offset if line 2 was present and is a valid float
+        if (z_offset_line[0] != '\0') {
+          char *end;
+          double z_offset_val = strtod(z_offset_line, &end);
+          if (end != z_offset_line) {
+            *len += snprintf(buffer + *len, buffer_size - *len,
+                            "{\"id\": %d, \"date\": \"%s\", \"mesh_data\": \"%s\", \"z_offset\": %.4f}",
+                            i, date_buf, mesh_data, z_offset_val);
+          } else {
+            *len += snprintf(buffer + *len, buffer_size - *len,
+                            "{\"id\": %d, \"date\": \"%s\", \"mesh_data\": \"%s\"}",
+                            i, date_buf, mesh_data);
+          }
+        } else {
+          *len += snprintf(buffer + *len, buffer_size - *len,
+                          "{\"id\": %d, \"date\": \"%s\", \"mesh_data\": \"%s\"}",
+                          i, date_buf, mesh_data);
+        }
         first_mesh = 0;
       }
     }

--- a/src/api/profiles.c
+++ b/src/api/profiles.c
@@ -128,14 +128,14 @@ void handle_get_profile(struct REQUEST *req, const char *profile_id_str) {
           "\"settings\": {"
           "\"grid_size\": %d,"
           "\"bed_temp\": %d,"
-          "\"precision\": %.4f,"
+          "\"precision\": %.4f"
+          "},"
+          "\"active_slot\": {"
+          "\"mesh_data\": \"%s\","
           "\"z_offset\": %.4f"
           "},"
-          "\"active_mesh\": {"
-          "\"mesh_data\": \"%s\""
-          "},"
-          "\"saved_meshes\": [",
-          mesh_grid, bed_temp, precision, z_offset, mesh_config);
+          "\"saved_slots\": [",
+          mesh_grid, bed_temp, precision, mesh_config, z_offset);
 
   // Read slots
   const char *slots_dir = is_current ? "/user/webfs" : NULL;

--- a/src/api/settings.c
+++ b/src/api/settings.c
@@ -54,8 +54,17 @@ void handle_put_profile_printer_mesh(struct REQUEST *req, const char *profile_id
     return;
   }
 
-  char *mesh_data = get_json_value(req->req_body, "\"mesh_data\"");
-  if (!mesh_data) {
+  // Note: get_json_value() uses a static buffer, copy values before next call
+  char mesh_data_buf[4096] = {0};
+  char z_offset_buf[32] = {0};
+
+  char *mesh_data_val = get_json_value(req->req_body, "\"mesh_data\"");
+  if (mesh_data_val) strncpy(mesh_data_buf, mesh_data_val, sizeof(mesh_data_buf) - 1);
+
+  char *z_offset_val = get_json_value(req->req_body, "\"z_offset\"");
+  if (z_offset_val) strncpy(z_offset_buf, z_offset_val, sizeof(z_offset_buf) - 1);
+
+  if (mesh_data_buf[0] == '\0') {
     snprintf(req->response_buffer, sizeof(req->response_buffer),
             "{\"status\": \"error\", \"message\": \"Invalid JSON payload. Missing 'mesh_data'.\"}");
     req->body = req->response_buffer;
@@ -92,7 +101,11 @@ void handle_put_profile_printer_mesh(struct REQUEST *req, const char *profile_id
     config_file = profile_cfg;
   }
 
-  if (update_printer_config_file(config_file, "points", mesh_data) == 0) {
+  if (update_printer_config_file(config_file, "points", mesh_data_buf) == 0) {
+    // If z_offset provided, also update it in the config file (safety: only if provided)
+    if (z_offset_buf[0] != '\0') {
+      update_printer_config_file(config_file, "z_offset", z_offset_buf);
+    }
     if (is_current) {
       snprintf(req->response_buffer, sizeof(req->response_buffer),
               "{\"status\": \"success\", \"message\": \"Active printer mesh updated. Please reboot for changes to take effect.\"}");
@@ -177,6 +190,13 @@ void handle_put_profile_settings(struct REQUEST *req, const char *profile_id_str
   tmp = get_json_value(body_copy, "\"precision\"");
   if (tmp) strncpy(precision_buf, tmp, sizeof(precision_buf) - 1);
   char *precision_str = precision_buf[0] ? precision_buf : NULL;
+
+  // Get z_offset and copy to local buffer
+  strcpy(body_copy, req->req_body);
+  char z_offset_buf[32] = {0};
+  tmp = get_json_value(body_copy, "\"z_offset\"");
+  if (tmp) strncpy(z_offset_buf, tmp, sizeof(z_offset_buf) - 1);
+  char *z_offset_str = z_offset_buf[0] ? z_offset_buf : NULL;
 
   const char *config_file;
   const char *cfg_filename;
@@ -284,6 +304,19 @@ void handle_put_profile_settings(struct REQUEST *req, const char *profile_id_str
     leveling_config = set_key_value(leveling_config, "precision", precision_str);
     write_config_file(params_file, leveling_config);
     LOG( "Leveling precision set to %s in %s\n", precision_str, params_file);
+  }
+
+  if (z_offset_str) {
+    if (update_printer_config_file(config_file, "z_offset", z_offset_str) != 0) {
+      snprintf(req->response_buffer, sizeof(req->response_buffer),
+              "{\"status\": \"error\", \"message\": \"Failed to update z_offset.\"}");
+      req->body = req->response_buffer;
+      req->lbody = strlen(req->response_buffer);
+      req->mime = "application/json";
+      mkheader(req, 500);
+      return;
+    }
+    LOG( "z_offset set to %s\n", z_offset_str);
   }
 
   // Log settings update

--- a/src/api/settings.c
+++ b/src/api/settings.c
@@ -104,7 +104,15 @@ void handle_put_profile_printer_mesh(struct REQUEST *req, const char *profile_id
   if (update_printer_config_file(config_file, "points", mesh_data_buf) == 0) {
     // If z_offset provided, also update it in the config file (safety: only if provided)
     if (z_offset_buf[0] != '\0') {
-      update_printer_config_file(config_file, "z_offset", z_offset_buf);
+      if (update_printer_config_file(config_file, "z_offset", z_offset_buf) != 0) {
+        snprintf(req->response_buffer, sizeof(req->response_buffer),
+                "{\"status\": \"error\", \"message\": \"Mesh updated but failed to update z_offset.\"}");
+        req->body = req->response_buffer;
+        req->lbody = strlen(req->response_buffer);
+        req->mime = "application/json";
+        mkheader(req, 500);
+        return;
+      }
     }
     if (is_current) {
       snprintf(req->response_buffer, sizeof(req->response_buffer),

--- a/src/api/slots.c
+++ b/src/api/slots.c
@@ -34,8 +34,24 @@ void handle_put_profile_slot(struct REQUEST *req, const char *profile_id_str, in
             "{\"status\": \"error\", \"message\": \"Missing request body.\"}");
     status_code = 400;
   } else {
-    char *mesh_data = get_json_value(req->req_body, "\"mesh_data\"");
-    if (mesh_data) {
+    // Note: get_json_value() uses a static buffer, copy values before next call
+    char mesh_data_buf[4096] = {0};
+    char z_offset_buf[32] = {0};
+
+    char *mesh_data_val = get_json_value(req->req_body, "\"mesh_data\"");
+    if (mesh_data_val) strncpy(mesh_data_buf, mesh_data_val, sizeof(mesh_data_buf) - 1);
+
+    char *z_offset_val = get_json_value(req->req_body, "\"z_offset\"");
+    if (z_offset_val) strncpy(z_offset_buf, z_offset_val, sizeof(z_offset_buf) - 1);
+
+    int has_mesh_data = (mesh_data_buf[0] != '\0');
+    int has_z_offset = (z_offset_buf[0] != '\0');
+
+    if (!has_mesh_data && !has_z_offset) {
+      snprintf(req->response_buffer, sizeof(req->response_buffer),
+              "{\"status\": \"error\", \"message\": \"Invalid JSON payload. Missing 'mesh_data' or 'z_offset'.\"}");
+      status_code = 400;
+    } else {
       char fn_buf[512];
       if (is_current) {
         snprintf(fn_buf, sizeof(fn_buf), "/user/webfs/data_slot_%d.txt", slot_id);
@@ -46,8 +62,38 @@ void handle_put_profile_slot(struct REQUEST *req, const char *profile_id_str, in
         snprintf(fn_buf, sizeof(fn_buf), "%s/data_slot_%d.txt", slots_dir, slot_id);
       }
 
-      if (custom_copy_file(NULL, fn_buf, "wb", mesh_data) == 0) {
-        // Log slot save
+      // If only z_offset provided (partial update), read existing mesh_data from file
+      if (!has_mesh_data && has_z_offset) {
+        FILE *existing = fopen(fn_buf, "r");
+        if (existing) {
+          if (fgets(mesh_data_buf, sizeof(mesh_data_buf) - 1, existing) != NULL) {
+            trim_trailing_whitespace(mesh_data_buf);
+          }
+          fclose(existing);
+          has_mesh_data = (mesh_data_buf[0] != '\0');
+        }
+        if (!has_mesh_data) {
+          snprintf(req->response_buffer, sizeof(req->response_buffer),
+                  "{\"status\": \"error\", \"message\": \"Slot file not found for partial update.\"}");
+          status_code = 404;
+          req->body = req->response_buffer;
+          req->lbody = strlen(req->response_buffer);
+          req->mime = "application/json";
+          mkheader(req, status_code);
+          return;
+        }
+      }
+
+      // Write file: line 1 = mesh_data, line 2 = z_offset (if provided)
+      FILE *f = fopen(fn_buf, "wb");
+      if (f) {
+        fputs(mesh_data_buf, f);
+        if (has_z_offset) {
+          fputc('\n', f);
+          fputs(z_offset_buf, f);
+        }
+        fclose(f);
+
         if (is_current) {
           LOG( "Mesh saved to slot %d\n", slot_id);
         } else {
@@ -61,10 +107,6 @@ void handle_put_profile_slot(struct REQUEST *req, const char *profile_id_str, in
                 "{\"status\": \"error\", \"message\": \"Failed to write to file.\"}");
         status_code = 500;
       }
-    } else {
-      snprintf(req->response_buffer, sizeof(req->response_buffer),
-              "{\"status\": \"error\", \"message\": \"Invalid JSON payload. Missing 'mesh_data'.\"}");
-      status_code = 400;
     }
   }
   req->body = req->response_buffer;

--- a/src/request.c
+++ b/src/request.c
@@ -446,22 +446,11 @@ int probe_count_y = 0;
 // last detected x_count & y_count, 0-unknown
 int x_count = 0;
 int y_count = 0;
-// web page grid size
-int new_grid_size = 0;
 // bed temperature
 int bed_temp = 60;
-// used profile number
-int used_profile = 1;
-int saved_profile = 1;
 
-// the number of mesh accumulation in mesh_acc[]
-int mesh_accumulations = 0;
-// mesh accumulator
-double mesh_acc[MESH_MATRIX_ELEMENTS];
 // mesh values (current bed leveling mesh)
 double mesh_values[MESH_MATRIX_ELEMENTS];
-// mesh average (calculated mesh average) or temp values during the average calculation
-double mesh_average[MESH_MATRIX_ELEMENTS];
 // selected average precision from the config file
 double precision = 0.01;
 // set Z-offset in the printer*.cfg file
@@ -484,41 +473,7 @@ void mesh_clear(double *mesh) {
         mesh[i] = 0.0;
 }
 
-// clear the mesh accumulator
-void mesh_acc_clear(void) {
-    mesh_clear(mesh_acc);
-    mesh_accumulations = 0;
-}
-
-// mesh_acc[] += mesh_values[] or mesh_acc[] += mesh_average[]
-// mesh_accumulations++
-void mesh_acc_add(double *value) {
-    int i;
-    for (i = 0; i < MESH_MATRIX_ELEMENTS; i++)
-        mesh_acc[i] += value[i];
-    mesh_accumulations++;
-}
-
-// mesh_average[] = mesh_acc[] / mesh_accumulations
-void mesh_acc_average(void) {
-    int i;
-    if (mesh_accumulations) {
-        if (mesh_accumulations == 1) {
-            // mesh_accumulations==1
-            for (i = 0; i < MESH_MATRIX_ELEMENTS; i++)
-                mesh_average[i] = mesh_acc[i];
-        } else {
-            // mesh_accumulations>=2
-            for (i = 0; i < MESH_MATRIX_ELEMENTS; i++)
-                mesh_average[i] = mesh_acc[i] / mesh_accumulations;
-        }
-    } else {
-        // mesh_accumulations==0
-        mesh_clear(mesh_average);
-    }
-}
-
-// convert mesh_values[grid x grid] or mesh_average[grid x grid] to mesh_matrix[grid x grid]
+// convert mesh_values[grid x grid] to mesh_matrix[grid x grid]
 // used format "%+1.4f"
 void mesh_matrix_export(double *mesh, int grid) {
     int x, y, i, ii;
@@ -544,57 +499,7 @@ void mesh_matrix_export(double *mesh, int grid) {
     }
 }
 
-// export mesh_average[] to buffer[] for printer.cfg setup
-void mesh_average_export(int grid, char *buffer) {
-    int x, y, i, ii;
-    i = 0;
-    ii = 0;
-    for (y = 0; y < grid; y++) {
-        for (x = 0; x < grid; x++) {
-            if ((x == (grid - 1)) && (y == (grid - 1))) {
-                // last point
-                sprintf(&buffer[ii], " %+1.6f", mesh_average[i]);
-                ii += 10;
-                buffer[ii] = 0;
-            } else {
-                if ((x == 0) && (y == 0)) {
-                    // first point
-                    sprintf(&buffer[ii], "%+1.6f,", mesh_average[i]);
-                    ii += 10;
-                    buffer[ii] = 0;
-                } else {
-                    // any other point
-                    sprintf(&buffer[ii], " %+1.6f,", mesh_average[i]);
-                    ii += 11;
-                    buffer[ii] = 0;
-                }
-            }
-            i++;
-        }
-    }
-}
-
-// return the number of the next available data slot (1-MAX_DATA_SLOTS)
-// or 0 if all slots are used
-int next_free_data_slot(void) {
-    int i;
-    char fn_buf[64];
-    int next = 0;
-    FILE *file;
-    for (i = 1; i < MAX_DATA_SLOTS; i++) {
-        sprintf(fn_buf, "/user/webfs/data_slot_%d.txt", i);
-        file = fopen(fn_buf, "r");
-        if (!file) {
-            next = i;
-            break;
-        } else {
-            fclose(file);
-        }
-    }
-    return next;
-}
-
-// parse the mesh values from config file string to mesh_values[] or mesh_average[]
+// parse the mesh values from config file string to mesh_values[]
 // return the number of parsed elements (not the grid size!)
 int parse_mesh_values(char *buffer, double *mesh) {
     int i;
@@ -613,64 +518,6 @@ int parse_mesh_values(char *buffer, double *mesh) {
         }
     }
     return nn;
-}
-
-// calculate mesh average for all used data slots
-// return the number of detected data slots
-// accumulate only data slots with provided grid_size
-// mesh_values[] = mesh_acc[all used data slots] / mesh_accumulations
-int calculate_mesh_average(int grid_size) {
-    int i, n, elements;
-    char fn_buf[64];
-    FILE *file;
-
-    mesh_acc_clear();
-
-    elements = grid_size * grid_size;
-
-    for (i = 1; i < MAX_DATA_SLOTS; i++) {
-        sprintf(fn_buf, "/user/webfs/data_slot_%d.txt", i);
-        file = fopen(fn_buf, "r");
-        if (file) {
-            fread(mesh_config, 1, MESH_BUFFER_SIZE, file);
-            fclose(file);
-            n = parse_mesh_values(mesh_config, mesh_average);
-            if (n == elements) {
-                mesh_acc_add(mesh_average);
-            }
-        }
-    }
-    mesh_acc_average();
-
-    return mesh_accumulations;
-}
-
-int export_selected_slot(int slot) {
-    int n, nn;
-    char fn_buf[64];
-    FILE *file;
-
-    n = 0;
-    sprintf(fn_buf, "/user/webfs/data_slot_%d.txt", slot);
-    file = fopen(fn_buf, "r");
-    if (file) {
-        fread(mesh_config, 1, MESH_BUFFER_SIZE, file);
-        fclose(file);
-        nn = parse_mesh_values(mesh_config, mesh_values);
-        n = GRID[nn & 0xFF];
-        mesh_matrix_export(mesh_values, n);
-    }
-    return n;
-}
-
-// apply provided precision to the provided buffer
-// buffer = mesh_values, precision=0.01
-void apply_precision(double *mesh, double precision) {
-    int i;
-    if (precision != 0.0) {
-        for (i = 0; i < MESH_MATRIX_ELEMENTS; i++)
-            mesh[i] = round(mesh[i] / precision) * precision;
-    }
 }
 
 // results:
@@ -767,11 +614,7 @@ int read_mesh_from_printer_config(void) {
     return read_mesh_from_config_file(k2_cfg);
 }
 
-char static_template_buffer[1024];
-char *static_template_ptr;
 config_option_t leveling_config = NULL;
-int error_code;
-int response_code;
 
 int get_ssh_status(void) {
     int ssh_status = 0;  // not installed
@@ -882,294 +725,6 @@ void get_memory_info(U64 *total_mem, U64 *free_mem) {
 }
 
 
-
-char *leveling_template_callback(char key) {
-    // response code replacement
-    if (key == '@') {
-        if (response_code == 1) {
-            static_template_ptr = "SUCCESS: The printer is preparing to reboot now ...";
-            return static_template_ptr;
-        }
-        if (response_code == 2) {
-            static_template_ptr = "SUCCESS: All data slots have been cleared!";
-            return static_template_ptr;
-        }
-        if (response_code == 3) {
-            static_template_ptr = "SUCCESS: Selected data slot has been cleared!";
-            return static_template_ptr;
-        }
-        if (response_code == 4) {
-            static_template_ptr = "SUCCESS: Current mesh has been saved in the selected data slot!";
-            return static_template_ptr;
-        }
-        if (response_code == 5) {
-            static_template_ptr = "SUCCESS: Calculated mesh average was set. Please reboot the printer to activate it!";
-            return static_template_ptr;
-        }
-        if (response_code == 6) {
-            static_template_ptr = "SUCCESS: Selected new arithmetic precision has been set!";
-            return static_template_ptr;
-        }
-        if (response_code == 7) {
-            return system_buffer;
-        }
-        if (response_code == 8) {
-            static_template_ptr = "SUCCESS: The requested command has been executed!";
-            return static_template_ptr;
-        }
-        if (response_code == 9) {
-            sprintf(static_template_buffer, "SUCCESS: Current printer configuration has been saved as a profile number %d.", saved_profile);
-            return static_template_buffer;
-        }
-        if (response_code == 10) {
-            sprintf(static_template_buffer, "SUCCESS: Profile %d is set to be used. Please reboot the printer!", saved_profile);
-            return static_template_buffer;
-        }
-        if (response_code == 11) {
-            sprintf(static_template_buffer, "SUCCESS: Selected bed mesh temperature %d C has been set!", bed_temp);
-            return static_template_buffer;
-        }
-        if (response_code == 12) {
-            static_template_ptr = "SUCCESS: The printer is preparing to power off ...";
-            return static_template_ptr;
-        }
-
-        // default - no response shown
-        static_template_buffer[0] = 0;
-        return static_template_buffer;
-    }
-    // error code replacement
-    if (key == '#') {
-        if (error_code == 1) {
-            static_template_ptr = "ERROR: No more free data slots are available!";
-            return static_template_ptr;
-        }
-        if (error_code == 2) {
-            static_template_ptr = "ERROR: Missing printer configuration file! Try to upload it from a backup.";
-            return static_template_ptr;
-        }
-        if (error_code == 3) {
-            static_template_ptr = "WARNING: No mesh data available in the config file! Please level the bed first!";
-            return static_template_ptr;
-        }
-        if (error_code == 4) {
-            static_template_ptr = "ERROR: Square grid is supported only! Select a new grid size and level the bed!";
-            return static_template_ptr;
-        }
-        if (error_code == 5) {
-            static_template_ptr = "ERROR: Probe grid size and bed mesh size do not match! Level the bed or select a new grid size!";
-            return static_template_ptr;
-        }
-        if (error_code == 6) {
-            static_template_ptr = "WARNING: The grid size has changed! Please reboot the printer and then level the bed.";
-            return static_template_ptr;
-        }
-        if (error_code == 7) {
-            static_template_ptr = "WARNING: The printer config file has changed! Please reboot the printer for the changes to be accepted.";
-            return static_template_ptr;
-        }
-        if (error_code == 8) {
-            static_template_ptr = "ERROR: The average cannot be used with all data slot cleared. Please save current mesh in a data slot first!";
-            return static_template_ptr;
-        }
-        if (error_code == 9) {
-            static_template_ptr = "ERROR: Selected data slot is out of the supported range!";
-            return static_template_ptr;
-        }
-        if (error_code == 10) {
-            static_template_ptr = "ERROR: Unsupported grid size!";
-            return static_template_ptr;
-        }
-        if (error_code == 11) {
-            static_template_ptr = "ERROR: Unsupported arithmetic precision!";
-            return static_template_ptr;
-        }
-        if (error_code == 12) {
-            static_template_ptr = "WARNING: No change detected in the requested parameters. These values are already set!";
-            return static_template_ptr;
-        }
-        if (error_code == 13) {
-            static_template_ptr = "ERROR: SSH service is not installed!";
-            return static_template_ptr;
-        }
-        if (error_code == 14) {
-            static_template_ptr = "ERROR: Invalid profile number!";
-            return static_template_ptr;
-        }
-        if (error_code == 15) {
-            static_template_ptr = "ERROR: Unable to detect the printer configuration!";
-            return static_template_ptr;
-        }
-        if (error_code == 16) {
-            static_template_ptr = "ERROR: Selected profile is already the current used profile!";
-            return static_template_ptr;
-        }
-        if (error_code == 17) {
-            static_template_ptr = "ERROR: Cannot save this profile!";
-            return static_template_ptr;
-        }
-        if (error_code == 18) {
-            static_template_ptr = "ERROR: Cannot read this profile!";
-            return static_template_ptr;
-        }
-        if (error_code == 19) {
-            static_template_ptr = "ERROR: Cannot use this profile!";
-            return static_template_ptr;
-        }
-        if (error_code == 20) {
-            static_template_ptr = "ERROR: Unsupported bed temperature!";
-            return static_template_ptr;
-        }
-        if (error_code == 99) {
-            static_template_ptr = "ERROR: Unsupported function requested!";
-            return static_template_ptr;
-        }
-        // default - no error shown
-        static_template_buffer[0] = 0;
-        return static_template_buffer;
-    }
-    if (key == 'E') {
-        // ---current mesh data---
-        return mesh_matrix;
-    }
-    if (key == 'F') {
-        // ---average mesh data---
-        apply_precision(mesh_average, precision);
-        mesh_matrix_export(mesh_average, mesh_grid);
-        return mesh_matrix;
-    }
-    if (key == 'A') {
-        // precision
-        char *precision_str = get_key_value(leveling_config, "precision", "0.01");
-        double precision = atof(precision_str);
-        sprintf(static_template_buffer, "%g", precision);
-        return static_template_buffer;
-    }
-    if (key == 'H') {
-        // used profile
-        char *profile_str = get_key_value(leveling_config, "used_profile", "1");
-        used_profile = atoi(profile_str);
-        if ((used_profile < 1) || (used_profile > 9))
-            used_profile = 1;
-        sprintf(static_template_buffer, "%d", used_profile);
-        return static_template_buffer;
-    }
-    if (key == 'Z') {
-        // Z-offset
-        sprintf(static_template_buffer, " Z-offset: %+g mm, Grid size used: %d, Grid size next: %d ", z_offset, mesh_grid, probe_count_x);
-        return static_template_buffer;
-    }
-    if (key == 'B') {
-        // grid size
-        if (new_grid_size != 0) {
-            // new grid size was set
-            sprintf(static_template_buffer, "%d", new_grid_size);
-        } else {
-            if (mesh_grid != 0) {
-                // current leveling grid size exists
-                sprintf(static_template_buffer, "%d", mesh_grid);
-            } else {
-                // next leveling grid size
-                sprintf(static_template_buffer, "%d", probe_count_x);
-            }
-        }
-        return static_template_buffer;
-    }
-    if (key == 'C') {
-        // next free slot
-        int next_free = next_free_data_slot();
-        sprintf(static_template_buffer, "%d", next_free);
-        return static_template_buffer;
-    }
-    if (key == 'X') {
-        // the number of slots to average
-        calculate_mesh_average(mesh_grid);
-        sprintf(static_template_buffer, "%d", mesh_accumulations);
-        return static_template_buffer;
-    }
-    if (key == 'T') {
-        // current bed mesh temperature
-        sprintf(static_template_buffer, "%d", bed_temp);
-        return static_template_buffer;
-    }
-    if (key == 'D') {
-        // slot to clear
-        static_template_buffer[0] = 0;
-        return static_template_buffer;
-    }
-    // default - empty string
-    static_template_buffer[0] = 0;
-    return static_template_buffer;
-}
-
-// convert a template to a result file in the help of template_element callback function
-// "{x}" is the template element "x", one char that will be expanded to the returned string
-// NOTE: just one template key per line is allowed!
-int populate_template_file(const char *src_file, const char *dst_file, char *(*template_element)(char key)) {
-    FILE *ifile;
-    FILE *ofile;
-    char *b = NULL;
-    size_t len = 0;
-    ssize_t read;
-    int i, n;
-    char key;
-    int key_beg;
-    int key_expanded_size;
-    char *key_expanded_value;
-
-    ifile = fopen(src_file, "r");
-    if (ifile) {
-        ofile = fopen(dst_file, "w");
-        if (ofile) {
-            while (1) {
-                read = getline(&b, &len, ifile);
-                if (read == -1) {
-                    break;
-                }
-                // line size
-                n = strlen(b);
-                if (n == 0)
-                    continue;
-
-                // line processing...
-                key_beg = -1;
-                for (i = 0; i < n; i++) {
-                    if ((b[i] == '{') && (b[i + 2] == '}')) {
-                        key_beg = i;
-                        key = b[i + 1];
-                        break;
-                    }
-                }
-                if (key_beg == -1) {
-                    // no template key found in this line, copy the line to the output
-                    fwrite(b, 1, n, ofile);
-                } else {
-                    // template key was found, so expand the key
-                    if (key_beg > 0) {
-                        // constant prefix found
-                        fwrite(b, 1, key_beg, ofile);
-                    }
-                    key_expanded_value = template_element(key);
-                    key_expanded_size = strlen(key_expanded_value);
-                    fwrite(key_expanded_value, 1, key_expanded_size, ofile);
-                    if (n > (key_beg + 3)) {
-                        fwrite(&b[key_beg + 3], 1, n - key_beg - 3, ofile);
-                    }
-                }
-            }
-            fclose(ifile);
-            fflush(ofile);
-            fclose(ofile);
-            if (b)
-                free(b);
-            return 0;
-        } else {
-            fclose(ifile);
-            return 2;
-        }
-    }
-    return 1;
-}
 
 // replace the value of a given parameter name for the provided config file
 // it will use a temporary file


### PR DESCRIPTION
## Summary

Z-offset stored per leveling slot, displayed inline, editable, averaged, and safely activated.

## Key Changes

- **C backend**: z_offset stored in slot files (two-line .txt format), included in API responses for slots, settings, and activation endpoint
- **Frontend**: z_offset field in leveling store, inline editing UI with precision-clamped display, averaged z-offset shown in slot list
- **E2E**: perf test for memory leak detection, z-offset functional test (inline editing + display validation)
- **Docs**: DOCS.md updated with z-offset feature documentation
- **Cleanup**: ~430 lines of dead C averaging code removed

## Fixes

Fixes #4

---

Assisted-by: 🤖 Claude Opus/Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-slot storage format and visible z-offset per slot with inline editing, read-only averaged z-offset, and "—" for legacy slots
  * Safe activation: activating a slot writes mesh points and z-offset when present; legacy slots preserve existing offset

* **Documentation**
  * Updated profiles/storage docs, troubleshooting, and legacy-slot migration guidance

* **Tests**
  * Added performance memory test and end-to-end z-offset editing tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->