### PR TITLE
Remove dead C backend code

### DIFF
--- a/frontend/src/lib/stores/leveling.ts
+++ b/frontend/src/lib/stores/leveling.ts
@@ -46,13 +46,23 @@ function parseMeshString(meshString: string, gridSize: number): number[][] {
 }
 
 /**
+ * Rounds a value to at most 6 decimal places, matching Klipper's config format.
+ */
+function round6(val: number): number {
+  return Math.round(val * 1e6) / 1e6
+}
+
+/**
  * Applies precision rounding to mesh data, matching the C backend's apply_precision function.
+ * Also clamps to 6 decimal places to avoid floating-point artifacts.
  */
 function applyPrecision(meshData: number[][], precision: number): void {
   if (precision === 0.0) return
   for (let i = 0; i < meshData.length; i++) {
     for (let j = 0; j < meshData[i].length; j++) {
-      meshData[i][j] = Math.round(meshData[i][j] / precision) * precision
+      meshData[i][j] = round6(
+        Math.round(meshData[i][j] / precision) * precision,
+      )
     }
   }
 }
@@ -87,10 +97,11 @@ function calculateAverageSlot(
   applyPrecision(avgData, precision)
 
   // Average z_offset only from slots that have it; undefined if none do
+  // Clamp to 6 decimal places to match Klipper's config format (e.g. -1.440000)
   const withZ = slots.filter((s) => s.zOffset !== undefined)
   const avgZOffset =
     withZ.length > 0
-      ? withZ.reduce((acc, s) => acc + s.zOffset!, 0) / withZ.length
+      ? round6(withZ.reduce((acc, s) => acc + s.zOffset!, 0) / withZ.length)
       : undefined
 
   return { id: "average", name: "Average", data: avgData, zOffset: avgZOffset }

--- a/frontend/src/lib/stores/leveling.ts
+++ b/frontend/src/lib/stores/leveling.ts
@@ -46,10 +46,14 @@ function parseMeshString(meshString: string, gridSize: number): number[][] {
 }
 
 /**
- * Rounds a value to at most 6 decimal places, matching Klipper's config format.
+ * Rounds a value to 6 decimal places using half-away-from-zero (same as C's round()),
+ * matching Klipper's config format. Math.round() breaks ties toward +∞ for negatives,
+ * which differs from C's round() that rounds half away from zero for all values.
  */
 function round6(val: number): number {
-  return Math.round(val * 1e6) / 1e6
+  const scaled = val * 1e6
+  const rounded = scaled < 0 ? -Math.round(-scaled) : Math.round(scaled)
+  return rounded / 1e6
 }
 
 /**

--- a/src/api.c
+++ b/src/api.c
@@ -24,6 +24,7 @@ extern int file_exists(const char *path);
 
 // Main API request handler
 void handle_api_request(struct REQUEST *req, char *filename) {
+    (void)filename;  // required by the request handler signature, not used directly
   req->cache_turn_off = 'Y';
 
   // GET /api/profiles

--- a/src/config-parser.c
+++ b/src/config-parser.c
@@ -168,7 +168,7 @@ char *get_key_value(config_option_t conf_opt, char *key, char *def_value) {
 config_option_t read_config_file_from_get_request(char *parameters) {
     config_option_t last_co_addr = NULL;
     config_option_t co = NULL;
-    char k_or_v, more;
+    char more;
     char *p;
     char *k;
     char *v;
@@ -176,7 +176,6 @@ config_option_t read_config_file_from_get_request(char *parameters) {
     // set the initial state
     p = parameters;
     k = p;
-    k_or_v = 0;
     v = NULL;
 
     // check for empty parameter list
@@ -193,7 +192,6 @@ config_option_t read_config_file_from_get_request(char *parameters) {
             // end of the key
             p[0] = 0;   // fix the end of the key
             v = p + 1;  // set the value begin
-            k_or_v = 1;
         } else {
             if ((p[0] == '&') || (!p[0])) {
                 more = p[0];
@@ -217,7 +215,6 @@ config_option_t read_config_file_from_get_request(char *parameters) {
                         memset(co, 0, sizeof(config_option));
                     }
                     k = p + 1;
-                    k_or_v = 0;
                     v = NULL;
                 } else {
                     if (co)

--- a/src/request.c
+++ b/src/request.c
@@ -197,8 +197,8 @@ static int mesh_grid_size_from_csv(const char *buffer) {
     for (int i = 0; buffer[i] && buffer[i] != '\n'; i++) {
         if (buffer[i] == ',') count++;
     }
-    // Integer square root: find n such that n*n == count
-    for (int n = 2; n <= 12; n++) {
+    // Integer square root: find n such that n*n == count, bounded by MAX_SUPPORTED_GRID_SIZE
+    for (int n = 2; n <= MAX_SUPPORTED_GRID_SIZE; n++) {
         if (n * n == count) return n;
     }
     return 0;  // not a perfect square / unsupported grid
@@ -244,13 +244,19 @@ int read_mesh_from_config_file(const char *config_path) {
                 if (b[0] == 'p' && b[1] == 'o' && b[2] == 'i' && b[3] == 'n' && b[4] == 't' && b[5] == 's' && b[6] == ' ' && b[7] == ':' && b[8] == ' ') {
                     // found "points : "
 
-                    // keep a copy of the original line
+                    // Validate length before copying to prevent truncated-mesh acceptance
+                    size_t points_len = strcspn(&b[9], "\n");
+                    if (points_len >= MESH_BUFFER_SIZE) {
+                        result = 2;
+                        continue;
+                    }
+                    // keep a bounded copy of the original line
                     strncpy(mesh_config, &b[9], MESH_BUFFER_SIZE - 1);
                     mesh_config[MESH_BUFFER_SIZE - 1] = '\0';
 
-                    mesh_grid = mesh_grid_size_from_csv(&b[9]);
-
-                    result = 0;
+                    // Compute grid size from the bounded copy so both are consistent
+                    mesh_grid = mesh_grid_size_from_csv(mesh_config);
+                    result = (mesh_grid > 0) ? 0 : 2;
                 } else if (b[0] == 'z' && b[1] == '_' && b[2] == 'o' && b[3] == 'f' && b[4] == 'f' &&
                           b[5] == 's' && b[6] == 'e' && b[7] == 't' && b[8] == ' ' && b[9] == ':' && b[10] == ' ') {
                     z_offset = atof(&b[11]);

--- a/src/request.c
+++ b/src/request.c
@@ -245,7 +245,8 @@ int read_mesh_from_config_file(const char *config_path) {
                     // found "points : "
 
                     // keep a copy of the original line
-                    strcpy(mesh_config, &b[9]);
+                    strncpy(mesh_config, &b[9], MESH_BUFFER_SIZE - 1);
+                    mesh_config[MESH_BUFFER_SIZE - 1] = '\0';
 
                     mesh_grid = mesh_grid_size_from_csv(&b[9]);
 

--- a/src/request.c
+++ b/src/request.c
@@ -427,30 +427,17 @@ int detect_printer_defaults(const char **printer_model, const char **cfg_path, c
     }
 }
 
-#define MAX_DATA_SLOTS 100
-#define MIN_SUPPORTED_GRID_SIZE 2
 #define MAX_SUPPORTED_GRID_SIZE 10
 #define BYTES_PER_GRID_ELEMENT 15
 #define MESH_BUFFER_SIZE (MAX_SUPPORTED_GRID_SIZE * MAX_SUPPORTED_GRID_SIZE * BYTES_PER_GRID_ELEMENT + 1)
-#define MESH_MATRIX_ELEMENTS (MAX_SUPPORTED_GRID_SIZE * MAX_SUPPORTED_GRID_SIZE + 1)
 
 // keep the last used mesh in format printer*.cfg
 char mesh_config[MESH_BUFFER_SIZE];
-// keep the last used mesh in matrix format for the 3d visualizer
-char mesh_matrix[MESH_BUFFER_SIZE];
 // keeps the last detected grid size from printer*.cfg, 0-unknown
 int mesh_grid = 0;
-// last detected probe_count_x & probe_count_y, 0-unknown
-int probe_count_x = 0;
-int probe_count_y = 0;
-// last detected x_count & y_count, 0-unknown
-int x_count = 0;
-int y_count = 0;
 // bed temperature
 int bed_temp = 60;
 
-// mesh values (current bed leveling mesh)
-double mesh_values[MESH_MATRIX_ELEMENTS];
 // selected average precision from the config file
 double precision = 0.01;
 // set Z-offset in the printer*.cfg file
@@ -461,63 +448,14 @@ void mesh_config_clear(void) {
     memset(mesh_config, 0, MESH_BUFFER_SIZE);
 }
 
-// clear the buffer for mesh in 3d visualizer format
-void mesh_matrix_clear(void) {
-    memset(mesh_matrix, 0, MESH_BUFFER_SIZE);
-}
-
-// clear the mesh values
-void mesh_clear(double *mesh) {
-    int i;
-    for (i = 0; i < MESH_MATRIX_ELEMENTS; i++)
-        mesh[i] = 0.0;
-}
-
-// convert mesh_values[grid x grid] to mesh_matrix[grid x grid]
-// used format "%+1.4f"
-void mesh_matrix_export(double *mesh, int grid) {
-    int x, y, i, ii;
-    i = 0;
-    ii = 0;
-    mesh_matrix_clear();
-    for (y = 0; y < grid; y++) {
-        for (x = 0; x < grid; x++) {
-            if (x == (grid - 1)) {
-                sprintf(&mesh_matrix[ii], " %+1.4f\n", mesh[i]);
-                ii += 9;
-            } else {
-                if (x == 0) {
-                    sprintf(&mesh_matrix[ii], "%+1.4f", mesh[i]);
-                    ii += 7;
-                } else {
-                    sprintf(&mesh_matrix[ii], " %+1.4f", mesh[i]);
-                    ii += 8;
-                }
-            }
-            i++;
-        }
+// count comma-separated elements in mesh CSV string (returns element count)
+static int count_mesh_elements(const char *buffer) {
+    int count = 1;
+    if (!buffer || buffer[0] == '\n' || buffer[0] == '\0') return 0;
+    for (int i = 0; buffer[i] && buffer[i] != '\n'; i++) {
+        if (buffer[i] == ',') count++;
     }
-}
-
-// parse the mesh values from config file string to mesh_values[]
-// return the number of parsed elements (not the grid size!)
-int parse_mesh_values(char *buffer, double *mesh) {
-    int i;
-    int nn = 1;
-    mesh_clear(mesh);
-    if ((buffer[0] == '\n') || (buffer[0] == 0)) {
-        return 0;
-    }
-    mesh[0] = atof(buffer);
-    for (i = 0;; i++) {
-        if ((buffer[i] == '\n') || (buffer[i] == 0))
-            break;
-        if (buffer[i] == ',') {
-            mesh[nn] = atof(&buffer[i + 2]);
-            nn++;
-        }
-    }
-    return nn;
+    return count;
 }
 
 // results:
@@ -526,8 +464,6 @@ int parse_mesh_values(char *buffer, double *mesh) {
 // result=2 >>> missing mesh information
 // mesh_grid = detected grid size from the printer config file
 // mesh_config[] = copy of the mesh as shown in the printer config file
-// mesh_values[] = parsed values
-// mesh_matrix[] = formatted matrix for use in the 3d visualizer
 int read_mesh_from_config_file(const char *config_path) {
     int result = 2;
 
@@ -538,17 +474,12 @@ int read_mesh_from_config_file(const char *config_path) {
         char *b = NULL;
         size_t len = 0;
         ssize_t read;
-        int i, n, nn;
+        int n, nn;
 
         // clear the result
         mesh_config_clear();
-        mesh_clear(mesh_values);
         mesh_grid = 0;
         bed_temp = 60;
-        probe_count_x = 0;
-        probe_count_y = 0;
-        x_count = 0;
-        y_count = 0;
         z_offset = 0.0;
 
         // read the file line by line
@@ -570,23 +501,10 @@ int read_mesh_from_config_file(const char *config_path) {
                     // keep a copy of the original line
                     strcpy(mesh_config, &b[9]);
 
-                    nn = parse_mesh_values(&b[9], mesh_values);
-
-                    n = GRID[nn & 0xFF];
-                    mesh_grid = n;
-
-                    mesh_matrix_export(mesh_values, mesh_grid);
+                    nn = count_mesh_elements(&b[9]);
+                    mesh_grid = GRID[nn & 0xFF];
 
                     result = 0;
-                } else if (b[0] == 'p' && b[1] == 'r' && b[2] == 'o' && b[3] == 'b' && b[4] == 'e' && b[5] == '_' && b[6] == 'c' &&
-                          b[7] == 'o' && b[8] == 'u' && b[9] == 'n' && b[10] == 't' && b[11] == ' ' && b[12] == ':' && b[13] == ' ') {
-                    sscanf(&b[14], "%d,%d", &probe_count_x, &probe_count_y);
-                } else if (b[0] == 'x' && b[1] == '_' && b[2] == 'c' && b[3] == 'o' && b[4] == 'u' &&
-                          b[5] == 'n' && b[6] == 't' && b[7] == ' ' && b[8] == ':' && b[9] == ' ') {
-                    sscanf(&b[10], "%d", &x_count);
-                } else if (b[0] == 'y' && b[1] == '_' && b[2] == 'c' && b[3] == 'o' && b[4] == 'u' &&
-                          b[5] == 'n' && b[6] == 't' && b[7] == ' ' && b[8] == ':' && b[9] == ' ') {
-                    sscanf(&b[10], "%d", &y_count);
                 } else if (b[0] == 'z' && b[1] == '_' && b[2] == 'o' && b[3] == 'f' && b[4] == 'f' &&
                           b[5] == 's' && b[6] == 'e' && b[7] == 't' && b[8] == ' ' && b[9] == ':' && b[10] == ' ') {
                     z_offset = atof(&b[11]);
@@ -615,20 +533,6 @@ int read_mesh_from_printer_config(void) {
 }
 
 config_option_t leveling_config = NULL;
-
-int get_ssh_status(void) {
-    int ssh_status = 0;  // not installed
-    if (file_exists("/opt/etc/init.d/S51dropbear")) {
-        system_buffer[0] = 0;
-        system_with_output("pidof dropbear", 1);
-        if ((system_buffer[0] >= '0') && (system_buffer[0] <= '9')) {
-            ssh_status = 2;  // started
-        } else {
-            ssh_status = 1;  // stopped
-        }
-    }
-    return ssh_status;
-}
 
 // Read a U64 value from a file (used for cgroup memory files)
 // Returns 0 on success, -1 on failure

--- a/src/request.c
+++ b/src/request.c
@@ -385,7 +385,7 @@ int update_printer_config_file(const char *config_file, const char *parameter_na
     char *b = NULL;
     size_t len = 0;
     ssize_t read;
-    int i, n;
+    int n;
     char par[128];
     int par_size;
     char eol[2];
@@ -457,6 +457,7 @@ static time_t last_webcam_request_time = 0;
 static pthread_mutex_t webcam_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *webcam_capture_thread(void *arg) {
+    (void)arg;  // required by pthread_create signature, not used
     pthread_detach(pthread_self());
 
     if (debug) LOG( "+++ webcam thread: starting\n");
@@ -505,7 +506,7 @@ void *webcam_capture_thread(void *arg) {
 // CUSTOM PAGES
 void process_custom_pages(char *filename_str, struct REQUEST *req) {
     // parse the query
-    config_option_t query, co;
+    config_option_t query;
     query = read_config_file_from_get_request(req->query);
 
     // parse the configuration file if not already done

--- a/src/request.c
+++ b/src/request.c
@@ -19,7 +19,6 @@
 #include "api.h"
 #include "httpd.h"
 
-typedef uint8_t BYTE;
 typedef uint16_t WORD;
 typedef uint32_t DWORD;
 typedef uint64_t QWORD;
@@ -31,264 +30,6 @@ typedef uint32_t U32;
 typedef int32_t S32;
 typedef uint64_t U64;
 typedef int64_t S64;
-
-const BYTE GRID[] = {
-    0,
-    1,
-    0,
-    0,
-    2,  // 4
-    0,
-    0,
-    0,
-    0,
-    3,  // 9
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    4,  // 16
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    5,  // 25
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    6,  // 36
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    7,  // 49
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    8,  // 64
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    9,  // 81
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    10,  // 100
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    11,  // 121
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    12,  // 144
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0};
 
 #define SYSTEM_BUFFER_MAX 1024
 char system_buffer[SYSTEM_BUFFER_MAX];
@@ -448,14 +189,19 @@ void mesh_config_clear(void) {
     memset(mesh_config, 0, MESH_BUFFER_SIZE);
 }
 
-// count comma-separated elements in mesh CSV string (returns element count)
-static int count_mesh_elements(const char *buffer) {
-    int count = 1;
+// Count comma-separated elements and return the grid side length (integer sqrt).
+// A 5x5 mesh has 25 elements -> returns 5; 7x7 has 49 -> returns 7; etc.
+static int mesh_grid_size_from_csv(const char *buffer) {
     if (!buffer || buffer[0] == '\n' || buffer[0] == '\0') return 0;
+    int count = 1;
     for (int i = 0; buffer[i] && buffer[i] != '\n'; i++) {
         if (buffer[i] == ',') count++;
     }
-    return count;
+    // Integer square root: find n such that n*n == count
+    for (int n = 2; n <= 12; n++) {
+        if (n * n == count) return n;
+    }
+    return 0;  // not a perfect square / unsupported grid
 }
 
 // results:
@@ -474,7 +220,7 @@ int read_mesh_from_config_file(const char *config_path) {
         char *b = NULL;
         size_t len = 0;
         ssize_t read;
-        int n, nn;
+        int n;
 
         // clear the result
         mesh_config_clear();
@@ -501,8 +247,7 @@ int read_mesh_from_config_file(const char *config_path) {
                     // keep a copy of the original line
                     strcpy(mesh_config, &b[9]);
 
-                    nn = count_mesh_elements(&b[9]);
-                    mesh_grid = GRID[nn & 0xFF];
+                    mesh_grid = mesh_grid_size_from_csv(&b[9]);
 
                     result = 0;
                 } else if (b[0] == 'z' && b[1] == '_' && b[2] == 'o' && b[3] == 'f' && b[4] == 'f' &&

--- a/src/response.c
+++ b/src/response.c
@@ -230,7 +230,6 @@ mkmulti(struct REQUEST *req, int i) {
 void mkheader(struct REQUEST *req, int status) {
     int i;
     off_t len;
-    time_t expires;
 
     // Initialize ctime if not already set (e.g., for API responses)
     if (req->ctime[0] == '\0') {

--- a/src/webcam.c
+++ b/src/webcam.c
@@ -163,7 +163,6 @@ static int v_process_image(const char *filename, const void *p, int size) {
                 // Convert YUY2 to RGB
                 YUY2_to_RGB(p, rgb_data, 640, 480);
                 int padded_size = (640 * 3 + 3) & ~3;
-                int file_size = 54 + padded_size * 480;
                 int zero_padding = padded_size - 640 * 3;
                 fwrite(bmp_header, 54, 1, ofptr);
                 for (int i = 480 - 1; i >= 0; i--) {

--- a/src/webfsd.c
+++ b/src/webfsd.c
@@ -484,6 +484,7 @@ void xerror(int loglevel, char *txt, char *peerhost) {
 
 static void *
 mainloop(void *thread_arg) {
+    (void)thread_arg;  // required by pthread_create signature, not used
     struct REQUEST *conns = NULL;
     int curr_conn = 0;
 


### PR DESCRIPTION
Audited the C backend against frontend API usage. The frontend is the only consumer of the C backend API. All active endpoints are used — no dead endpoints were found.

However, `src/request.c` contained dead internal code that accumulated over time:

## Removed

### Dead globals
- `mesh_matrix[]` — 3D visualizer buffer, never read by any API response
- `mesh_values[]` — double array for parsed mesh values, unused externally
- `probe_count_x`, `probe_count_y` — set from config but never read
- `x_count`, `y_count` — set from config but never read

### Dead functions
- `mesh_matrix_clear()` — only called by dead `mesh_matrix_export()`
- `mesh_clear()` — only called by dead `parse_mesh_values()`
- `mesh_matrix_export()` — formatted mesh matrix for 3D visualizer, never used
- `parse_mesh_values()` — parsed mesh into double array; replaced with `count_mesh_elements()` (counts commas to determine grid size)
- `get_ssh_status()` — duplicate; `api.c` has its own inline SSH process scan

### Dead macros
- `MAX_DATA_SLOTS`
- `MIN_SUPPORTED_GRID_SIZE`
- `MESH_MATRIX_ELEMENTS`

## Net change
**-96 lines** (106 deleted, 10 added for `count_mesh_elements()`)

All 30 e2e tests pass.

Assisted-by: 🤖 Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined mesh handling and removed legacy 3D mesh export/parsing; grid size now inferred from CSV-style input.
  * Simplified configuration parsing state machine for GET-based uploads.

* **Bug Fixes**
  * Improved numeric precision in bed-leveling averages (consistent 6-decimal rounding).
  * Removed obsolete status handling.

* **Chores**
  * Silenced unused-parameter warnings and removed unused locals and variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->