### PR TITLE
fix(ui): leveling page overflow, compact card titles, delete-all in header

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -12,17 +12,32 @@
   .card {
     background-color: var(--card-background-color);
     border-radius: 8px;
-    padding: 1rem;
+    padding: 0.75rem;
     transition:
       background-color 0.2s,
       border-color 0.2s;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.5rem;
     min-height: 0;
     min-width: 0;
   }
   .no-padding {
     padding: 0;
+  }
+
+  /* Global card title style used across all cards */
+  :global(.card-title) {
+    margin: 0;
+    padding-bottom: 0.35rem;
+    border-bottom: 1px solid var(--card-border-color);
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85em;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    opacity: 0.75;
   }
 </style>

--- a/frontend/src/lib/components/ProfileSelector.svelte
+++ b/frontend/src/lib/components/ProfileSelector.svelte
@@ -50,10 +50,12 @@
     display: flex;
     gap: 0.5rem;
     align-items: center;
+    min-width: 0;
   }
 
   select {
     flex: 1;
+    min-width: 0;
     padding: 0.5rem;
     border: 1px solid var(--card-border-color);
     border-radius: 5px;
@@ -61,6 +63,8 @@
     color: var(--text-color);
     font-size: 1rem;
     cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   select:disabled {
@@ -78,8 +82,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    min-width: 2.5rem;
-    height: 2.5rem;
+    min-width: 2rem;
+    width: 2rem;
+    height: 2rem;
+    flex-shrink: 0;
   }
 
   .icon-button:hover {

--- a/frontend/src/lib/components/system-tools/system-tools.css
+++ b/frontend/src/lib/components/system-tools/system-tools.css
@@ -1,15 +1,5 @@
 /* Shared styles for system-tools components */
 
-.card-title {
-  margin: 0;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--card-border-color);
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 1.1em;
-}
-
 .tool-section {
   display: flex;
   flex-direction: column;

--- a/frontend/src/routes/leveling/+page.svelte
+++ b/frontend/src/routes/leveling/+page.svelte
@@ -929,6 +929,8 @@
   @media (max-width: 900px) {
     .page-container {
       grid-template-columns: 1fr;
+      overflow-y: auto;
+      height: auto;
     }
   }
 </style>

--- a/frontend/src/routes/leveling/+page.svelte
+++ b/frontend/src/routes/leveling/+page.svelte
@@ -375,7 +375,7 @@
   <div class="page-container">
     <div class="column">
       <!-- Profile Selector Card -->
-      <Card>
+      <Card style="flex-shrink: 0;">
         <svelte:fragment slot="title">
           <h3 class="card-title">
             <FontAwesomeIcon icon={faUser} /> Profile
@@ -556,9 +556,20 @@
       <!-- Saved Bed Meshes Card -->
       <Card style="flex-grow: 1; min-height: 0;">
         <svelte:fragment slot="title">
-          <h3 class="card-title">
-            <FontAwesomeIcon icon={faHdd} /> Saved Bed Meshes
-          </h3>
+          <div class="card-title-row">
+            <h3 class="card-title">
+              <FontAwesomeIcon icon={faHdd} /> Saved Bed Meshes
+            </h3>
+            {#if $levelingStore.savedSlots.length > 0}
+              <button
+                class="header-danger-btn"
+                title="Delete all saved meshes"
+                on:click={deleteAllSlots}
+              >
+                <FontAwesomeIcon icon={faTrash} />
+              </button>
+            {/if}
+          </div>
         </svelte:fragment>
         <div class="mesh-list">
           {#each $levelingStore.savedSlots as slot (slot.id)}
@@ -625,11 +636,6 @@
             </div>
           {/each}
         </div>
-        <div class="button-group spaced">
-          <button class="danger" on:click={deleteAllSlots}
-            ><FontAwesomeIcon icon={faTrash} /> Delete all</button
-          >
-        </div>
       </Card>
     </div>
 
@@ -690,10 +696,11 @@
 <style>
   .page-container {
     display: grid;
-    grid-template-columns: 35% 1fr;
-    gap: 1rem;
-    padding: 1rem;
+    grid-template-columns: minmax(260px, 35%) 1fr;
+    gap: 0.5rem;
+    padding: 0.5rem;
     height: 100%;
+    overflow: hidden;
   }
 
   .loading-container,
@@ -720,14 +727,16 @@
   .column {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.5rem;
     min-height: 0;
+    overflow: hidden;
   }
 
   .column-group {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.5rem;
+    flex-shrink: 0;
   }
 
   .visualizer-content {
@@ -746,20 +755,36 @@
   .visualizer-column {
     min-height: 0;
   }
-  .card-title {
-    margin: 0;
-    border-bottom: 1px solid var(--card-border-color);
-    padding-bottom: 0.75rem;
-    margin-bottom: -0.25rem;
+
+  .card-title-row {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .header-danger-btn {
+    padding: 0.15rem 0.35rem;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: #dc3545;
+    cursor: pointer;
+    opacity: 0.7;
+    font-size: 0.85em;
+    display: flex;
+    align-items: center;
+    transition: opacity 0.15s;
+  }
+  .header-danger-btn:hover {
+    opacity: 1;
+    background-color: rgba(220, 53, 69, 0.1);
   }
 
   .settings-form {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(3, 1fr) auto;
+    gap: 0.5rem;
     align-items: flex-end;
   }
   .settings-form .button-group {
@@ -790,9 +815,6 @@
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
-  }
-  .button-group.spaced {
-    justify-content: space-between;
   }
 
   button {

--- a/frontend/src/routes/leveling/+page.svelte
+++ b/frontend/src/routes/leveling/+page.svelte
@@ -564,6 +564,8 @@
               <button
                 class="header-danger-btn"
                 title="Delete all saved meshes"
+                aria-label="Delete all saved meshes"
+                type="button"
                 on:click={deleteAllSlots}
               >
                 <FontAwesomeIcon icon={faTrash} />


### PR DESCRIPTION
## Summary

Fixes UI quirks on the leveling page and improves spacing across the whole app.

## Changes

### Leveling page overflow fix
- Fix broken height constraint chain: add `overflow: hidden` to `.page-container` and `.column`
- Add `flex-shrink: 0` to profile Card and `.column-group` so they stay at natural height
- Use `minmax(260px, 35%)` for left column to prevent over-squishing on narrow windows
- Saved Bed Meshes card now properly fills remaining space and scrolls its list

### Reduced cramped spacing
- Reduce card padding: `1rem → 0.75rem`
- Reduce all gaps between cards and inside cards: `1rem → 0.5rem`
- Fix settings-form grid to `repeat(3, 1fr) auto` — prevents unwanted row wrap on smaller windows

### Slim card titles (global, all pages)
- Move `.card-title` style into `Card.svelte` as `:global` — single source of truth
- Titles are now compact: smaller font (0.85em), uppercase, reduced padding
- Remove duplicate `.card-title` definitions from `system-tools.css` and leveling page

### "Delete all" moved to card header
- Moved from prominent bottom footer to an icon-only trash button in the Saved Bed Meshes card header title row
- Button is hidden when there are no slots (nothing to delete)
- 0.7 opacity at rest, full opacity on hover with subtle red background

### ProfileSelector overflow fix
- Add `min-width: 0` to selector container and `select` element
- Add `text-overflow: ellipsis` on select for narrow windows
- Add `flex-shrink: 0` to icon buttons so they never get pushed off-screen
- Slightly reduce icon button size (`2.5rem → 2rem`)

Assisted-by: 🤖 Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined card spacing and typography with reduced padding and gaps for a denser layout
  * Introduced a unified card title/header row and updated header button styling with improved hover feedback
  * Improved text overflow handling in the profile selector with ellipsis support and tighter control sizing
  * Moved the "Delete All" action into the card header for clearer visibility and alignment
  * Adjusted grid and container spacing and overflow handling for a more compact, consistent layout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->