### PR TITLE
feat: per-file license separation (Apache 2.0 / GPL-2.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: REUSE license compliance
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: REUSE license compliance
+        uses: fsfe/reuse-action@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024-2026 Chris Suszynski (@cardil)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/GPL-2.0-only.txt
+++ b/LICENSES/GPL-2.0-only.txt
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/LICENSES/LicenseRef-PublicDomain.txt
+++ b/LICENSES/LicenseRef-PublicDomain.txt
@@ -1,0 +1,14 @@
+Public Domain
+
+The author or authors of this code dedicate any and all copyright interest
+in this code to the public domain. We make this dedication for the benefit
+of the public at large. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this code
+under copyright law.
+
+This code is provided "AS IS", without warranty of any kind, express or
+implied, including but not limited to the warranties of merchantability,
+fitness for a particular purpose, and noninfringement. In no event shall
+the authors be liable for any claim, damages, or other liability, whether
+in an action of contract, tort, or otherwise, arising from, out of, or in
+connection with the code or the use or other dealings in the code.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # --- Pre-execution Setup ---
 
 # Define colors and icons for better readability

--- a/README.md
+++ b/README.md
@@ -164,7 +164,17 @@ See the development guides in [frontend/README.md](frontend/README.md) and [src/
 
 ## 📜 License
 
-Open source project. Check individual files for specific licenses. Built on WEBFS (public domain) and incorporates various open-source libraries.
+This project uses a **split license** model:
+
+| Component | License | Files |
+|-----------|---------|-------|
+| AK2 Dashboard (frontend, API, scripts, tests) | [Apache 2.0](LICENSE) | `frontend/`, `src/api*`, `scripts/`, `e2e/` |
+| WEBFS-derived HTTP server | [GPL-2.0-only](COPYING) | `src/webfsd.c`, `src/request.c`, `src/response.c`, `src/ls.c`, `src/mime.c`, `src/httpd.h` |
+| V4L2 webcam capture | Public Domain | `src/webcam.c` |
+
+The **compiled binary** as a whole is covered by GPL-2.0 (the most restrictive component).
+New contributions default to Apache 2.0 per the root [`LICENSE`](LICENSE) file.
+Each source file declares its own license via an SPDX header; see [`REUSE.toml`](REUSE.toml) for project-wide declarations.
 
 ## ⚠️ Important Disclaimers
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ This project uses a **split license** model:
 
 | Component | License | Files |
 |-----------|---------|-------|
-| AK2 Dashboard (frontend, API, scripts, tests) | [Apache 2.0](LICENSE) | `frontend/`, `src/api*`, `scripts/`, `e2e/` |
+| AK2 Dashboard (frontend, API, scripts, tests) | [Apache 2.0](LICENSE) | All files not listed below |
 | WEBFS-derived HTTP server | [GPL-2.0-only](COPYING) | `src/webfsd.c`, `src/request.c`, `src/response.c`, `src/ls.c`, `src/mime.c`, `src/httpd.h` |
 | V4L2 webcam capture | Public Domain | `src/webcam.c` |
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This project uses a **split license** model:
 | WEBFS-derived HTTP server | [GPL-2.0-only](COPYING) | `src/webfsd.c`, `src/request.c`, `src/response.c`, `src/ls.c`, `src/mime.c`, `src/httpd.h` |
 | V4L2 webcam capture | Public Domain | `src/webcam.c` |
 
-The **compiled binary** as a whole is covered by GPL-2.0 (the most restrictive component).
+The **compiled binary** as a whole is covered by GPL-2.0-only (the most restrictive component).
 New contributions default to Apache 2.0 per the root [`LICENSE`](LICENSE) file.
 Each source file declares its own license via an SPDX header; see [`REUSE.toml`](REUSE.toml) for project-wide declarations.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+#
+# REUSE specification: https://reuse.software/spec/
+# This file declares copyright and license for files that cannot have
+# comment headers (binaries, images, lock files, etc.).
+# Per-file SPDX headers in source files take precedence over entries here.
+
+version = 1
+
+# ── Default: all project files are Apache-2.0 ─────────────────────────────────
+[[annotations]]
+path = ["**"]
+SPDX-License-Identifier = "Apache-2.0"
+SPDX-FileCopyrightText = "2024-2026 Chris Suszynski (@cardil)"
+
+# ── WEBFS-derived backend files: GPL-2.0-only ─────────────────────────────────
+# These files originate from WEBFS by Gerd Hoffmann and were modified by
+# AGG2017 and Chris Suszynski. GPL-2.0 is mandatory; it cannot be changed.
+[[annotations]]
+path = [
+  "src/webfsd.c",
+  "src/request.c",
+  "src/response.c",
+  "src/ls.c",
+  "src/mime.c",
+  "src/httpd.h",
+]
+SPDX-License-Identifier = "GPL-2.0-only"
+SPDX-FileCopyrightText = [
+  "1999-2003 Gerd Hoffmann <kraxel@bytesex.org>",
+  "2017 AGG2017",
+  "2024-2026 Chris Suszynski (@cardil)",
+]
+
+# ── V4L2 webcam capture: public domain ────────────────────────────────────────
+# Based on V4L2 video capture example (public domain reference implementation).
+[[annotations]]
+path = ["src/webcam.c"]
+SPDX-License-Identifier = "LicenseRef-PublicDomain"
+SPDX-FileCopyrightText = [
+  "2017 AGG2017",
+  "2024-2026 Chris Suszynski (@cardil)",
+]

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # E2E Testbed Dockerfile - Simulates Tina Linux printer environment
 # Tina Linux = OpenWRT + glibc 2.23 (Allwinner's custom build)
 # We create a hybrid by sideloading glibc from Ubuntu 16.04 into OpenWRT rootfs

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # E2E Test Makefile
 # This Makefile contains all E2E testbed and testing targets
 

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ak2-e2e-tests",
       "version": "1.0.0",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "devDependencies": {
         "@lavamoat/allow-scripts": "^3.3.1",
         "@lavamoat/preinstall-always-fail": "^2.1.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ak2-e2e-tests",
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "description": "E2E tests for AK2 Dashboard using Playwright",
   "type": "module",
   "scripts": {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({

--- a/e2e/scripts/entrypoint.sh
+++ b/e2e/scripts/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # E2E Testbed entrypoint script
 # Starts services and handles signals properly for graceful shutdown
 

--- a/e2e/scripts/gen-bed-mesh.sh
+++ b/e2e/scripts/gen-bed-mesh.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # Simulates bed mesh leveling by generating mesh points and z-offset in printer.cfg
 # This mimics what the vendor app does when running bed leveling
 

--- a/e2e/scripts/healthcheck.sh
+++ b/e2e/scripts/healthcheck.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # E2E Testbed health check script
 # Verifies that dropbear SSH server is running and listening on port 22
 

--- a/e2e/tests/config.ts
+++ b/e2e/tests/config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 /**
  * E2E Test Configuration
  *

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import type { APIRequestContext } from '@playwright/test';

--- a/e2e/tests/home.spec.ts
+++ b/e2e/tests/home.spec.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { test, expect } from '@playwright/test';
 import { EXPECT_TIMEOUT } from './config';
 

--- a/e2e/tests/leveling.spec.ts
+++ b/e2e/tests/leveling.spec.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { test, expect } from '@playwright/test';
 import { generateBedMesh } from './helpers';
 import { EXPECT_TIMEOUT, UI_TRANSITION_TIMEOUT } from './config';

--- a/e2e/tests/perf.ts
+++ b/e2e/tests/perf.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 /**
  * Memory Leak Detection Script
  *

--- a/e2e/tests/system-tools.spec.ts
+++ b/e2e/tests/system-tools.spec.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { test, expect } from '@playwright/test';
 import { fetchLogTail } from './helpers';
 import { EXPECT_TIMEOUT, SERVICE_OPERATION_TIMEOUT, LOG_REFRESH_TIMEOUT } from './config';

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # --- Frontend Makefile ---
 
 # Define colors and icons for better readability

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "frontend",
       "version": "0.0.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.1.0",
         "@fortawesome/free-regular-svg-icons": "^7.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "private": true,
   "version": "0.0.1",
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 declare global {

--- a/frontend/src/echarts-gl.d.ts
+++ b/frontend/src/echarts-gl.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 declare module "echarts-gl/charts" {
   const SurfaceChart: any
   export { SurfaceChart }

--- a/frontend/src/lib/api/profiles.ts
+++ b/frontend/src/lib/api/profiles.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // frontend/src/lib/api/profiles.ts
 
 // --- API Data Structures ---

--- a/frontend/src/lib/components/BedMeshDataTable.svelte
+++ b/frontend/src/lib/components/BedMeshDataTable.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { theme } from "$lib/stores/theme"
 

--- a/frontend/src/lib/components/BedMeshVisualizer.svelte
+++ b/frontend/src/lib/components/BedMeshVisualizer.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { onMount, onDestroy, createEventDispatcher } from "svelte"
   import type { ECharts, EChartsOption } from "echarts"

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   export let noPadding = false
   export let style = ""

--- a/frontend/src/lib/components/ConnectionOverlay.svelte
+++ b/frontend/src/lib/components/ConnectionOverlay.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import {
     kobraConnectionStore,

--- a/frontend/src/lib/components/EditorModal.svelte
+++ b/frontend/src/lib/components/EditorModal.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { createEventDispatcher, onMount } from "svelte"
   import { effectiveTheme } from "$lib/stores/theme"

--- a/frontend/src/lib/components/FileBrowser.svelte
+++ b/frontend/src/lib/components/FileBrowser.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { fileBrowserStore } from "$lib/stores/fileBrowser"
   import { onMount } from "svelte"

--- a/frontend/src/lib/components/FileEntry.svelte
+++ b/frontend/src/lib/components/FileEntry.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { FontAwesomeIcon } from "@fortawesome/svelte-fontawesome"
   import { faDatabase, faRedo } from "@fortawesome/free-solid-svg-icons"

--- a/frontend/src/lib/components/InfoModal.svelte
+++ b/frontend/src/lib/components/InfoModal.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { createEventDispatcher } from "svelte"
 

--- a/frontend/src/lib/components/InfoWidget.svelte
+++ b/frontend/src/lib/components/InfoWidget.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   export let label: string
   export let title: string = ""

--- a/frontend/src/lib/components/NavMenu.svelte
+++ b/frontend/src/lib/components/NavMenu.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import ThemeSwitcher from "$lib/components/ThemeSwitcher.svelte"
   import Logo from "$lib/components/icons/Logo.svelte"

--- a/frontend/src/lib/components/PrintHistory.svelte
+++ b/frontend/src/lib/components/PrintHistory.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import RefreshIcon from "$lib/components/icons/RefreshIcon.svelte"
   import Card from "$lib/components/Card.svelte"

--- a/frontend/src/lib/components/PrinterControls.svelte
+++ b/frontend/src/lib/components/PrinterControls.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import ThermometerIcon from "$lib/components/icons/ThermometerIcon.svelte"
   import NozzleIcon from "$lib/components/icons/NozzleIcon.svelte"

--- a/frontend/src/lib/components/PrinterSelector.svelte
+++ b/frontend/src/lib/components/PrinterSelector.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { printerStore } from "$lib/stores/printer"
   import { activePrinterIdStore } from "$lib/stores/activePrinterId"

--- a/frontend/src/lib/components/PrinterStats.svelte
+++ b/frontend/src/lib/components/PrinterStats.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import Card from "$lib/components/Card.svelte"
   import { formatDuration, parseUptime } from "$lib/utils/time"

--- a/frontend/src/lib/components/ProfileManagerModal.svelte
+++ b/frontend/src/lib/components/ProfileManagerModal.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { profilesStore } from "$lib/stores/profiles"
   import { FontAwesomeIcon } from "@fortawesome/svelte-fontawesome"

--- a/frontend/src/lib/components/ProfileSelector.svelte
+++ b/frontend/src/lib/components/ProfileSelector.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { profilesStore } from "$lib/stores/profiles"
   import { FontAwesomeIcon } from "@fortawesome/svelte-fontawesome"

--- a/frontend/src/lib/components/SaveAsModal.svelte
+++ b/frontend/src/lib/components/SaveAsModal.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { profilesStore } from "$lib/stores/profiles"
   import { toast } from "svelte-sonner"

--- a/frontend/src/lib/components/SaveMeshModal.svelte
+++ b/frontend/src/lib/components/SaveMeshModal.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { createEventDispatcher } from "svelte"
 

--- a/frontend/src/lib/components/Spinner.svelte
+++ b/frontend/src/lib/components/Spinner.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <!--
 A simple, self-contained CSS spinner component.
 -->

--- a/frontend/src/lib/components/ThemeSwitcher.svelte
+++ b/frontend/src/lib/components/ThemeSwitcher.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { onMount } from "svelte"
   import { theme, type Theme } from "$lib/stores/theme"

--- a/frontend/src/lib/components/Webcam.svelte
+++ b/frontend/src/lib/components/Webcam.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { onDestroy } from "svelte"
   import CameraOffIcon from "$lib/components/icons/CameraOffIcon.svelte"

--- a/frontend/src/lib/components/icons/BedMeshIcon.svelte
+++ b/frontend/src/lib/components/icons/BedMeshIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/CameraOffIcon.svelte
+++ b/frontend/src/lib/components/icons/CameraOffIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <!--
   This component renders an inline SVG of a camera with a slash through it.
   Using it as a Svelte component allows the `currentColor` property to correctly

--- a/frontend/src/lib/components/icons/ClockIcon.svelte
+++ b/frontend/src/lib/components/icons/ClockIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/EtaIcon.svelte
+++ b/frontend/src/lib/components/icons/EtaIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/FanIcon.svelte
+++ b/frontend/src/lib/components/icons/FanIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script>
 </script>
 

--- a/frontend/src/lib/components/icons/FilamentIcon.svelte
+++ b/frontend/src/lib/components/icons/FilamentIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script>
 </script>
 

--- a/frontend/src/lib/components/icons/FilesIcon.svelte
+++ b/frontend/src/lib/components/icons/FilesIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/HomeIcon.svelte
+++ b/frontend/src/lib/components/icons/HomeIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/LayersIcon.svelte
+++ b/frontend/src/lib/components/icons/LayersIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/LevelingIcon.svelte
+++ b/frontend/src/lib/components/icons/LevelingIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/Logo.svelte
+++ b/frontend/src/lib/components/icons/Logo.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="180"
   height="24"

--- a/frontend/src/lib/components/icons/NozzleIcon.svelte
+++ b/frontend/src/lib/components/icons/NozzleIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
   <path
     d="M7,2H17V7H19V13H16.5L13,17H11L7.5,13H5V7H7V2M10,22H2V20H10A1,1 0 0,0 11,19V18H13V19A3,3 0 0,1 10,22M7,9V11H8.5L12,15L15.5,11H17V9H15V4H9V9H7Z"

--- a/frontend/src/lib/components/icons/PauseIcon.svelte
+++ b/frontend/src/lib/components/icons/PauseIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/PlayIcon.svelte
+++ b/frontend/src/lib/components/icons/PlayIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/RefreshIcon.svelte
+++ b/frontend/src/lib/components/icons/RefreshIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/ReprintIcon.svelte
+++ b/frontend/src/lib/components/icons/ReprintIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/SpeedIcon.svelte
+++ b/frontend/src/lib/components/icons/SpeedIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script>
 </script>
 

--- a/frontend/src/lib/components/icons/StatusIcon.svelte
+++ b/frontend/src/lib/components/icons/StatusIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/StopIcon.svelte
+++ b/frontend/src/lib/components/icons/StopIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/SystemToolsIcon.svelte
+++ b/frontend/src/lib/components/icons/SystemToolsIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import Fa from "svelte-fa"
   import { faTools } from "@fortawesome/free-solid-svg-icons"

--- a/frontend/src/lib/components/icons/ThermometerIcon.svelte
+++ b/frontend/src/lib/components/icons/ThermometerIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/icons/ZOffsetIcon.svelte
+++ b/frontend/src/lib/components/icons/ZOffsetIcon.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <svg
   width="24"
   height="24"

--- a/frontend/src/lib/components/system-tools/FileBrowserCard.svelte
+++ b/frontend/src/lib/components/system-tools/FileBrowserCard.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import Card from "$lib/components/Card.svelte"
   import FileBrowser from "$lib/components/FileBrowser.svelte"

--- a/frontend/src/lib/components/system-tools/PrinterLogCard.svelte
+++ b/frontend/src/lib/components/system-tools/PrinterLogCard.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import Card from "$lib/components/Card.svelte"
   import { logStore } from "$lib/stores/log"

--- a/frontend/src/lib/components/system-tools/SecurityCard.svelte
+++ b/frontend/src/lib/components/system-tools/SecurityCard.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import Card from "$lib/components/Card.svelte"
   import { faShieldHalved, faLock } from "@fortawesome/free-solid-svg-icons"

--- a/frontend/src/lib/components/system-tools/ServicesCard.svelte
+++ b/frontend/src/lib/components/system-tools/ServicesCard.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import Card from "$lib/components/Card.svelte"
   import InfoWidget from "$lib/components/InfoWidget.svelte"

--- a/frontend/src/lib/components/system-tools/SystemCard.svelte
+++ b/frontend/src/lib/components/system-tools/SystemCard.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import Card from "$lib/components/Card.svelte"
   import InfoWidget from "$lib/components/InfoWidget.svelte"

--- a/frontend/src/lib/components/system-tools/system-tools.css
+++ b/frontend/src/lib/components/system-tools/system-tools.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) */
 /* Shared styles for system-tools components */
 
 .tool-section {

--- a/frontend/src/lib/dev/mockLocalCommands.ts
+++ b/frontend/src/lib/dev/mockLocalCommands.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // frontend/src/lib/dev/mockLocalCommands.ts
 import { webserverStore } from "$lib/stores/webserver"
 import { pushState } from "$app/navigation"

--- a/frontend/src/lib/dev/mockProxy.ts
+++ b/frontend/src/lib/dev/mockProxy.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // frontend/src/lib/dev/mockProxy.ts
 import { browser } from "$app/environment"
 import { localMockCommands } from "./mockLocalCommands"

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // place files you want to import through the `$lib` alias in this folder.

--- a/frontend/src/lib/stores/activePrinterId.ts
+++ b/frontend/src/lib/stores/activePrinterId.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { writable } from "svelte/store"
 
 function createActivePrinterIdStore() {

--- a/frontend/src/lib/stores/fileBrowser.ts
+++ b/frontend/src/lib/stores/fileBrowser.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { writable, get } from "svelte/store"
 import { browser } from "$app/environment"
 

--- a/frontend/src/lib/stores/kobraConnection.ts
+++ b/frontend/src/lib/stores/kobraConnection.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // frontend/src/lib/stores/kobraConnection.ts
 import { writable } from "svelte/store"
 

--- a/frontend/src/lib/stores/leveling.ts
+++ b/frontend/src/lib/stores/leveling.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { get, writable } from "svelte/store"
 import { browser } from "$app/environment"
 import * as api from "$lib/api/profiles"

--- a/frontend/src/lib/stores/log.ts
+++ b/frontend/src/lib/stores/log.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { writable } from "svelte/store"
 import { browser } from "$app/environment"
 

--- a/frontend/src/lib/stores/printer.ts
+++ b/frontend/src/lib/stores/printer.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { get, writable } from "svelte/store"
 import io from "socket.io-client"
 import { webserverStore } from "./webserver"

--- a/frontend/src/lib/stores/profiles.ts
+++ b/frontend/src/lib/stores/profiles.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { writable, get } from "svelte/store"
 import { browser } from "$app/environment"
 import * as api from "$lib/api/profiles"

--- a/frontend/src/lib/stores/system.ts
+++ b/frontend/src/lib/stores/system.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { writable } from "svelte/store"
 import { browser } from "$app/environment"
 

--- a/frontend/src/lib/stores/theme.ts
+++ b/frontend/src/lib/stores/theme.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { writable, readable, get } from "svelte/store"
 import { browser } from "$app/environment"
 

--- a/frontend/src/lib/stores/time.ts
+++ b/frontend/src/lib/stores/time.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // frontend/src/lib/stores/time.ts
 import { readable } from "svelte/store"
 

--- a/frontend/src/lib/stores/webserver.ts
+++ b/frontend/src/lib/stores/webserver.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { writable, get } from "svelte/store"
 import { browser } from "$app/environment"
 

--- a/frontend/src/lib/utils/binary.ts
+++ b/frontend/src/lib/utils/binary.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 /**
  * Check if content is binary by looking for NULL bytes and invalid UTF-8
  */

--- a/frontend/src/lib/utils/files.ts
+++ b/frontend/src/lib/utils/files.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // frontend/src/lib/utils/files.ts
 
 /**

--- a/frontend/src/lib/utils/time.ts
+++ b/frontend/src/lib/utils/time.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 /**
  * Parses an uptime string in "HH:MM:SS" format into a total number of seconds.
  * @param uptimeString The uptime string to parse.

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import favicon from "$lib/assets/favicon.svg"
   import NavMenu from "$lib/components/NavMenu.svelte"

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import { onMount } from "svelte"
   import Webcam from "$lib/components/Webcam.svelte"

--- a/frontend/src/routes/docs/+page.svelte
+++ b/frontend/src/routes/docs/+page.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import Card from "$lib/components/Card.svelte"
   import type { PageData } from "./$types"

--- a/frontend/src/routes/docs/+page.ts
+++ b/frontend/src/routes/docs/+page.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { marked } from "marked"
 import docsMarkdown from "../../../../DOCS.md?raw"
 

--- a/frontend/src/routes/leveling/+page.svelte
+++ b/frontend/src/routes/leveling/+page.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import Card from "$lib/components/Card.svelte"
   import BedMeshVisualizer from "$lib/components/BedMeshVisualizer.svelte"

--- a/frontend/src/routes/system-tools/+page.svelte
+++ b/frontend/src/routes/system-tools/+page.svelte
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil) -->
 <script lang="ts">
   import InfoModal from "$lib/components/InfoModal.svelte"
   import { systemInfo } from "$lib/stores/system"

--- a/frontend/src/svelte-fa.d.ts
+++ b/frontend/src/svelte-fa.d.ts
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 declare module "svelte-fa"

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import adapter from "@sveltejs/adapter-static"
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte"
 

--- a/frontend/test/components/Card.test.ts
+++ b/frontend/test/components/Card.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { render, screen } from "@testing-library/svelte"
 import { describe, it, expect } from "vitest"
 import TestCard from "./TestCard.svelte"

--- a/frontend/test/mocks/buildMockCommands.mjs
+++ b/frontend/test/mocks/buildMockCommands.mjs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import fs from "fs"
 import path from "path"
 import {

--- a/frontend/test/mocks/hmr.ts
+++ b/frontend/test/mocks/hmr.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import type { ViteDevServer } from "vite"
 import type { Server as SocketIOServer } from "socket.io"
 import type { Printer } from "./kobraData"

--- a/frontend/test/mocks/kobraData.ts
+++ b/frontend/test/mocks/kobraData.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 export interface PrintJob {
   taskid: string
   filename: string

--- a/frontend/test/mocks/kobraUnleashedMock.ts
+++ b/frontend/test/mocks/kobraUnleashedMock.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { Server as SocketIOServer } from "socket.io"
 import { mockPrinter, type Printer, type PrintJob } from "./kobraData"
 import type { ViteDevServer, Connect } from "vite"

--- a/frontend/test/mocks/levelingApi.ts
+++ b/frontend/test/mocks/levelingApi.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import type { Connect } from "vite"
 
 // This file will mock the C backend API for profiles.

--- a/frontend/test/mocks/logMock.ts
+++ b/frontend/test/mocks/logMock.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // Mock log functionality for testing
 // Generates and manages a mock log file that can simulate large log files
 

--- a/frontend/test/mocks/mockApi.ts
+++ b/frontend/test/mocks/mockApi.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import fs from "fs"
 import path from "path"
 import type { Connect } from "vite"

--- a/frontend/test/mocks/mockCommandParser.mjs
+++ b/frontend/test/mocks/mockCommandParser.mjs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import fs from "fs"
 import path from "path"
 import ts from "typescript"

--- a/frontend/test/mocks/mockCommands.ts
+++ b/frontend/test/mocks/mockCommands.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import * as fs from "fs"
 import type { Server as SocketIOServer } from "socket.io"
 import type { Printer } from "./kobraData"

--- a/frontend/test/mocks/systemApi.ts
+++ b/frontend/test/mocks/systemApi.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import type { Connect } from "vite"
 import fs from "fs"
 import path from "path"

--- a/frontend/test/setup.ts
+++ b/frontend/test/setup.ts
@@ -1,2 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // This file is used for global test setup
 import "@testing-library/jest-dom"

--- a/frontend/test/smoke/dev-server.test.ts
+++ b/frontend/test/smoke/dev-server.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { createServer } from "vite"
 import fetch from "node-fetch"
 import { describe, it, expect, beforeAll, afterAll } from "vitest"

--- a/frontend/test/smoke/setup.ts
+++ b/frontend/test/smoke/setup.ts
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 // This file is intentionally blank to override the global test setup for smoke tests.

--- a/frontend/test/smoke/vitest.config.ts
+++ b/frontend/test/smoke/vitest.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 import { sveltekit } from "@sveltejs/kit/vite"
 import { defineConfig } from "vitest/config"
 import fs from "fs"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # Deploy webserver to printer via SSH
 
 set -e

--- a/scripts/get-deploy-config.sh
+++ b/scripts/get-deploy-config.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # Script to get deployment configuration for printer
 # Reuses config directory from kobra2-fw-tools for consistency
 

--- a/scripts/pull-base-images.sh
+++ b/scripts/pull-base-images.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # Pull base images from a Dockerfile only if not already cached locally.
 # Usage: pull-base-images.sh <default-platform> <dockerfile>
 # This avoids podman's forced "pull=newer" behavior for cross-platform builds,

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # --- Backend Makefile ---
 
 # Define colors and icons for better readability

--- a/src/api.c
+++ b/src/api.c
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <sys/sysinfo.h>

--- a/src/api.h
+++ b/src/api.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #ifndef API_H
 #define API_H
 

--- a/src/api/helpers.c
+++ b/src/api/helpers.c
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <sys/stat.h>

--- a/src/api/helpers.h
+++ b/src/api/helpers.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #ifndef API_HELPERS_H
 #define API_HELPERS_H
 

--- a/src/api/profiles.c
+++ b/src/api/profiles.c
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <stdio.h>

--- a/src/api/profiles.h
+++ b/src/api/profiles.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #ifndef API_PROFILES_H
 #define API_PROFILES_H
 

--- a/src/api/settings.c
+++ b/src/api/settings.c
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <stdio.h>

--- a/src/api/settings.h
+++ b/src/api/settings.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #ifndef API_SETTINGS_H
 #define API_SETTINGS_H
 

--- a/src/api/slots.c
+++ b/src/api/slots.c
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <stdio.h>

--- a/src/api/slots.h
+++ b/src/api/slots.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #ifndef API_SLOTS_H
 #define API_SLOTS_H
 

--- a/src/build.Dockerfile
+++ b/src/build.Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # ARM compiler for webfsd cross-compilation with glibc
 # Uses Debian Jessie (glibc 2.19) - backward compatible with printer's glibc 2.23
 # Native ARM gcc via QEMU emulation

--- a/src/config-parser.c
+++ b/src/config-parser.c
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/src/httpd.h
+++ b/src/httpd.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 1999-2003 Gerd Hoffmann <kraxel@bytesex.org>
+// SPDX-FileCopyrightText: 2017 AGG2017
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #ifndef HTTPD_H
 #define HTTPD_H
 

--- a/src/ls.c
+++ b/src/ls.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 1999-2003 Gerd Hoffmann <kraxel@bytesex.org>
+// SPDX-FileCopyrightText: 2017 AGG2017
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <ctype.h>
 #include <dirent.h>
 #include <fcntl.h>

--- a/src/mime.c
+++ b/src/mime.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 1999-2003 Gerd Hoffmann <kraxel@bytesex.org>
+// SPDX-FileCopyrightText: 2017 AGG2017
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/in.h>

--- a/src/request.c
+++ b/src/request.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 1999-2003 Gerd Hoffmann <kraxel@bytesex.org>
+// SPDX-FileCopyrightText: 2017 AGG2017
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/src/response.c
+++ b/src/response.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 1999-2003 Gerd Hoffmann <kraxel@bytesex.org>
+// SPDX-FileCopyrightText: 2017 AGG2017
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>

--- a/src/webcam.c
+++ b/src/webcam.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: LicenseRef-PublicDomain
+// SPDX-FileCopyrightText: 2017 AGG2017
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 /*
 *  V4L2 video capture example
 *	http://linuxtv.org/downloads/v4l-dvb-apis/capture-example.html

--- a/src/webfsd.c
+++ b/src/webfsd.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 1999-2003 Gerd Hoffmann <kraxel@bytesex.org>
+// SPDX-FileCopyrightText: 2017 AGG2017
+// SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
+//
 #include <errno.h>
 #include <fcntl.h>
 #include <grp.h>

--- a/webserver/opt/bin/webfsd-runner
+++ b/webserver/opt/bin/webfsd-runner
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-2026 Chris Suszynski (@cardil)
 # Webfsd startup wrapper script
 # Provides unified startup for webfsd with configuration file support
 # Used by both rc.local and deployment scripts


### PR DESCRIPTION
## Summary

The project contains two distinct license lineages that need to be properly declared:

- **WEBFS-derived HTTP server files** originate from [WEBFS by Gerd Hoffmann](http://linux.bytesex.org/misc/webfs.html) (GPL-2.0). The GPL-2.0 is mandatory and cannot be changed.
- **Everything else** (API layer, frontend, scripts, tests) was written from scratch and is Apache-2.0.

This PR makes those per-file licenses explicit and machine-readable using the SPDX + REUSE specification.

## Approach: Hybrid REUSE + dual root files

- **`LICENSE`** (Apache-2.0) + **`COPYING`** (GPL-2.0) at root → GitHub sidebar detects both licenses
- **`LICENSES/`** directory with both canonical texts → REUSE tooling (`reuse lint`) compliance  
- **`REUSE.toml`** → catch-all Apache-2.0 for all files; explicit GPL-2.0 override for 6 WEBFS files; public-domain for `webcam.c`
- **Per-file SPDX headers** in every source file → unambiguous per-file declaration readable by humans and tools

## License mapping

| Component | License |
|-----------|---------|
| `src/webfsd.c`, `src/request.c`, `src/response.c`, `src/ls.c`, `src/mime.c`, `src/httpd.h` | GPL-2.0-only |
| `src/webcam.c` | LicenseRef-PublicDomain |
| All other source files | Apache-2.0 |

The compiled binary as a whole remains GPL-2.0 (most restrictive component wins). New contributions default to Apache-2.0.

## Changes

- **New:** `LICENSE`, `LICENSES/Apache-2.0.txt`, `LICENSES/GPL-2.0-only.txt`, `REUSE.toml`
- **Modified:** All source files (C, headers, Makefiles, shell scripts, TypeScript, Svelte, CSS) — SPDX headers added
- **Modified:** `frontend/package.json`, `e2e/package.json` — added `"license": "Apache-2.0"` field
- **Modified:** `e2e/Dockerfile`, `src/build.Dockerfile` — SPDX headers added
- **Modified:** `README.md` — license section updated with split-license table

Closes #15

Assisted-by: 🤖 Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New UI components: info widget, save-mesh modal, and additional icons.
  * File size formatting utility for human-readable file sizes.

* **Documentation**
  * Clarified split licensing model in README.
  * Added full Apache-2.0 and GPL-2.0 license texts and REUSE metadata across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->