### PR TITLE
Fix display defaults bug during print

### DIFF
--- a/frontend/src/lib/components/PrinterControls.svelte
+++ b/frontend/src/lib/components/PrinterControls.svelte
@@ -99,7 +99,7 @@
   $: speedMode = (() => {
     const mode = printer?.print_job?.print_speed_mode
     if (mode === undefined || mode === null || mode < 0) return "N/A"
-    return ["Silent", "Normal", "Sport"][mode] ?? "N/A"
+    return ["Stable", "Standard", "Sport"][mode] ?? "N/A"
   })()
   $: formattedZOffset = (() => {
     const offset = Number(printer?.print_job?.z_offset ?? 0)

--- a/frontend/src/lib/components/PrinterControls.svelte
+++ b/frontend/src/lib/components/PrinterControls.svelte
@@ -99,7 +99,8 @@
   $: speedMode = (() => {
     const mode = printer?.print_job?.print_speed_mode
     if (mode === undefined || mode === null || mode < 0) return "N/A"
-    return ["Stable", "Standard", "Sport"][mode] ?? "N/A"
+    // Firmware uses 1-based mode: 1=Stable, 2=Standard, 3=Sport
+    return ["Stable", "Standard", "Sport"][mode - 1] ?? "N/A"
   })()
   $: formattedZOffset = (() => {
     const offset = Number(printer?.print_job?.z_offset ?? 0)

--- a/frontend/src/lib/stores/printer.ts
+++ b/frontend/src/lib/stores/printer.ts
@@ -81,6 +81,10 @@ import { browser } from "$app/environment"
 function createPrinterStore() {
   const { subscribe, set, update } = writable<{ [id: string]: Printer }>({})
   let socket: any
+  // Tracks task IDs that have received at least one non-zero z_offset.
+  // Once seen, any subsequent 0.0 for the same task is treated as the
+  // kobra-unleashed PrintJob sentinel (cardil/kobra-unleashed#4), not a real value.
+  const tasksWithRealZOffset = new Set<string>()
 
   webserverStore.subscribe((config) => {
     // Disconnect from the old socket if it exists
@@ -155,14 +159,31 @@ function createPrinterStore() {
             // real values that arrived via print/update messages (~10x less
             // frequent). We keep the previous values when:
             // 1. Both old and new print_job exist for the same task
-            // 2. The incoming value is the sentinel default (-1 or 0.0)
+            // 2. The incoming value is the sentinel default (-1)
+            //
+            // For z_offset: 0.0 is technically valid but is also the kobra-unleashed
+            // PrintJob default. We use a heuristic: once a non-zero z_offset has been
+            // observed for a task, treat all subsequent 0.0 values as the sentinel.
+            // Before seeing any non-zero value, 0.0 is displayed as-is.
             const prevJob = existingPrinter?.print_job
             const newJob = updatedPrinter.print_job
             if (newJob && prevJob && newJob.taskid === prevJob.taskid) {
               if (newJob.fan_speed < 0) newJob.fan_speed = prevJob.fan_speed
-              if (newJob.z_offset === 0.0) newJob.z_offset = prevJob.z_offset
+              if (newJob.z_offset !== 0.0) {
+                // Record that this task has real z_offset data
+                tasksWithRealZOffset.add(newJob.taskid)
+              } else if (tasksWithRealZOffset.has(newJob.taskid)) {
+                // 0.0 after a real value → sentinel, retain last known good
+                newJob.z_offset = prevJob.z_offset
+              }
               if (newJob.print_speed_mode < 0)
                 newJob.print_speed_mode = prevJob.print_speed_mode
+            } else if (
+              newJob &&
+              (!prevJob || newJob.taskid !== prevJob?.taskid)
+            ) {
+              // New task started — clear sentinel tracking for old tasks
+              tasksWithRealZOffset.clear()
             }
 
             return {

--- a/frontend/src/lib/stores/printer.ts
+++ b/frontend/src/lib/stores/printer.ts
@@ -182,9 +182,15 @@ function createPrinterStore() {
               newJob &&
               (!prevJob || newJob.taskid !== prevJob?.taskid)
             ) {
-              // New task started — drop only old task tracking, then seed
-              // new task if the first update already has a real non-zero value
-              if (prevJob) tasksWithRealZOffset.delete(prevJob.taskid)
+              // New task started — drop tracking for old and new task ids
+              // to avoid stale sentinel state from a previous print with the
+              // same taskid (e.g. after idle/null transition). Then seed if
+              // first update already carries a real non-zero value.
+              if (prevJob) {
+                tasksWithRealZOffset.delete(prevJob.taskid)
+              } else {
+                tasksWithRealZOffset.delete(newJob.taskid)
+              }
               if (newJob.z_offset !== 0.0)
                 tasksWithRealZOffset.add(newJob.taskid)
             }

--- a/frontend/src/lib/stores/printer.ts
+++ b/frontend/src/lib/stores/printer.ts
@@ -182,8 +182,11 @@ function createPrinterStore() {
               newJob &&
               (!prevJob || newJob.taskid !== prevJob?.taskid)
             ) {
-              // New task started — clear sentinel tracking for old tasks
-              tasksWithRealZOffset.clear()
+              // New task started — drop only old task tracking, then seed
+              // new task if the first update already has a real non-zero value
+              if (prevJob) tasksWithRealZOffset.delete(prevJob.taskid)
+              if (newJob.z_offset !== 0.0)
+                tasksWithRealZOffset.add(newJob.taskid)
             }
 
             return {

--- a/frontend/src/lib/stores/printer.ts
+++ b/frontend/src/lib/stores/printer.ts
@@ -148,6 +148,23 @@ function createPrinterStore() {
               updatedPrinter.files = existingPrinter.files
             }
 
+            // Retain last-known-good print job settings when the backend sends
+            // sentinel/default values. This is a frontend workaround for a
+            // kobra-unleashed bug (cardil/kobra-unleashed#4) where every
+            // print/start MQTT message recreates PrintJob with defaults, wiping
+            // real values that arrived via print/update messages (~10x less
+            // frequent). We keep the previous values when:
+            // 1. Both old and new print_job exist for the same task
+            // 2. The incoming value is the sentinel default (-1 or 0.0)
+            const prevJob = existingPrinter?.print_job
+            const newJob = updatedPrinter.print_job
+            if (newJob && prevJob && newJob.taskid === prevJob.taskid) {
+              if (newJob.fan_speed < 0) newJob.fan_speed = prevJob.fan_speed
+              if (newJob.z_offset === 0.0) newJob.z_offset = prevJob.z_offset
+              if (newJob.print_speed_mode < 0)
+                newJob.print_speed_mode = prevJob.print_speed_mode
+            }
+
             return {
               ...currentPrinters,
               [id]: updatedPrinter,

--- a/frontend/test/mocks/kobraUnleashedMock.ts
+++ b/frontend/test/mocks/kobraUnleashedMock.ts
@@ -358,6 +358,21 @@ function startPrintSimulation(io: SocketIOServer) {
 
   const simulationInterval = 250 // Update 4 times per second for smoothness
 
+  // Simulate the real firmware behavior from MQTT capture:
+  // - print/start messages (~10x more frequent) reset settings to defaults
+  //   because kobra-unleashed recreates PrintJob on every start message
+  // - print/update messages arrive every ~20s real-world time
+  // This reproduces the bug described in issue #10.
+  //
+  // Scale the update period by speedMultiplier so it feels right at any speed:
+  // real 20s / speedMultiplier / 0.25s per tick = 80 / speedMultiplier ticks
+  const updatePeriodTicks = Math.max(
+    4,
+    Math.round(80 / simulation.speedMultiplier),
+  )
+  // Randomize initial offset so first update arrives at an unpredictable point
+  let tickCount = Math.floor(Math.random() * updatePeriodTicks)
+
   printJobInterval = setInterval(() => {
     const job = printer.print_job!
     const sim = simulation!
@@ -381,6 +396,21 @@ function startPrintSimulation(io: SocketIOServer) {
       (simulationInterval / 1000) *
       sim.speedMultiplier
     job.supplies_usage += filamentIncrease
+
+    tickCount++
+    const isUpdateTick = tickCount % updatePeriodTicks === 0
+    if (isUpdateTick) {
+      // Simulate print/update: set real values (Sport mode during print,
+      // fan oscillates between 50-100% as the firmware adjusts cooling)
+      job.fan_speed = 50 + Math.floor(Math.random() * 6) * 10 // 50,60,70,80,90,100
+      job.z_offset = -1.57
+      job.print_speed_mode = 2 // Sport during active print
+    } else {
+      // Simulate print/start: kobra-unleashed resets to sentinel defaults
+      job.fan_speed = -1
+      job.z_offset = 0.0
+      job.print_speed_mode = -1
+    }
 
     emitPrinterUpdate(io, printer)
   }, simulationInterval)
@@ -434,6 +464,10 @@ function startPreheating(io: SocketIOServer) {
   let currentStep = 0
   const initialNozzleTemp = Number(printer.nozzle_temp)
   const initialBedTemp = Number(printer.hotbed_temp)
+  // Pick a random step during preheating where print/update brings real values.
+  // Real firmware sends print/update every ~20s during preheating too.
+  // We pick 1-2 random steps to simulate this.
+  const updateStep = 1 + Math.floor(Math.random() * (steps - 2))
 
   tempInterval = setInterval(() => {
     currentStep++
@@ -456,6 +490,23 @@ function startPreheating(io: SocketIOServer) {
         initialBedTemp + (TARGET_BED_TEMP - initialBedTemp) * fraction,
       ),
     )
+
+    // Simulate print/update arriving during preheating: one step carries real
+    // settings (Standard mode, fan at 100%), all others reset to sentinel
+    // defaults (from kobra-unleashed recreating PrintJob on print/start)
+    const job = printer.print_job
+    if (job) {
+      if (currentStep === updateStep) {
+        job.fan_speed = 100
+        job.z_offset = -1.57
+        job.print_speed_mode = 1 // Standard during preheating
+      } else {
+        job.fan_speed = -1
+        job.z_offset = 0.0
+        job.print_speed_mode = -1
+      }
+    }
+
     emitPrinterUpdate(io, printer)
   }, 1000)
 }

--- a/frontend/test/mocks/kobraUnleashedMock.ts
+++ b/frontend/test/mocks/kobraUnleashedMock.ts
@@ -402,9 +402,10 @@ function startPrintSimulation(io: SocketIOServer) {
     if (isUpdateTick) {
       // Simulate print/update: set real values (Sport mode during print,
       // fan oscillates between 50-100% as the firmware adjusts cooling)
+      // Firmware uses 1-based mode: 1=Stable, 2=Standard, 3=Sport
       job.fan_speed = 50 + Math.floor(Math.random() * 6) * 10 // 50,60,70,80,90,100
       job.z_offset = -1.57
-      job.print_speed_mode = 2 // Sport during active print
+      job.print_speed_mode = 3 // Sport (1-based) during active print
     } else {
       // Simulate print/start: kobra-unleashed resets to sentinel defaults
       job.fan_speed = -1
@@ -494,12 +495,13 @@ function startPreheating(io: SocketIOServer) {
     // Simulate print/update arriving during preheating: one step carries real
     // settings (Standard mode, fan at 100%), all others reset to sentinel
     // defaults (from kobra-unleashed recreating PrintJob on print/start)
+    // Firmware uses 1-based mode: 1=Stable, 2=Standard, 3=Sport
     const job = printer.print_job
     if (job) {
       if (currentStep === updateStep) {
         job.fan_speed = 100
         job.z_offset = -1.57
-        job.print_speed_mode = 1 // Standard during preheating
+        job.print_speed_mode = 2 // Standard (1-based) during preheating
       } else {
         job.fan_speed = -1
         job.z_offset = 0.0


### PR DESCRIPTION
## Summary

Fixes #10 — Fan speed, z-offset, and speed mode always showing defaults during print.

## Root Cause

kobra-unleashed recreates `PrintJob` with sentinel defaults on every `print/start` MQTT message (every ~1s), wiping real values that arrive via `print/update` (~every 20s). This is a ~10:1 overwrite ratio. Frontend blindly accepted all updates including the sentinel resets.

Full analysis posted in [issue comment](https://github.com/cardil/ak2-dashboard/issues/10#issuecomment-4633019710).

## Changes

### `frontend/src/lib/stores/printer.ts`
- In the `printer_updated` handler, retain last-known-good `fan_speed`, `z_offset`, `print_speed_mode` when the backend sends sentinel defaults (`-1` or `0.0`) and `taskid` matches the current job.

### `frontend/src/lib/components/PrinterControls.svelte`
- Fix speed mode labels: `["Silent", "Normal", "Sport"]` → `["Stable", "Standard", "Sport"]` (confirmed from MQTT capture showing modes 1=Standard, 2=Sport).

### `frontend/test/mocks/kobraUnleashedMock.ts`
- Simulate real firmware behavior: sentinel defaults overwrite real values ~97.5% of ticks
- Update period scales with `speedMultiplier` so it feels realistic at any sim speed
- Randomized initial `tickCount` offset
- Preheating phase: emits real values (Standard mode, fan 100%) on one random step
- Printing phase: Sport mode, fan oscillates 50–100%

## Testing

Reproduced with dev server mock before fix (values flicker to N/A constantly), confirmed stable display after fix.

Assisted-by: 🤖 Claude Opus/Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced print job settings stability to prevent unexpected resets during printing operations, reducing unwanted UI disruptions and improving overall reliability.

* **UI Updates**
  * Updated speed mode display labels from Silent/Normal/Sport to Stable/Standard/Sport for clearer mode identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->