### PR TITLE
Fix supported printer models

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -422,7 +422,7 @@ A: Absolutely! The project is open source and welcomes contributions. See the Gi
 
 **Q: Does this work with all Kobra 2 models?**
 
-A: Yes, it supports K2, K2 Pro, K2 Plus, and K2 Max.
+A: No. This project is designed for **KobraOS**-based printers — specifically the **K2 Pro, K2 Plus, and K2 Max**. It does **not** support the K2 base model or K2 Neo. Printers with the Spe_B board can technically run it, but [Rinkhals](https://jbatonnet.github.io/Rinkhals) is likely a better fit for those.
 
 **Q: What about Kobra 3?**
 


### PR DESCRIPTION
Clarify which Kobra 2 models are supported in the FAQ.

- K2 base and K2 Neo are not supported
- Only K2 Pro, K2 Plus, K2 Max (KobraOS-based) are supported
- Note that Spe_B board users may prefer Rinkhals

Assisted-by: 🤖 Claude Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cardil/ak2-dashboard/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Kobra 2 model compatibility information in FAQ, specifying which models are supported and any configuration limitations for optimal use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->